### PR TITLE
fix(airflow): add Java to Airflow container for SparkSubmitOperator

### DIFF
--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -1,5 +1,12 @@
 FROM apache/airflow:2.8.0-python3.11
 
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openjdk-17-jdk-headless \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+
+USER airflow
 # Copy from docker/airflow directory (relative to build context which is project root)
 COPY docker/airflow/requirements-airflow.txt /requirements-airflow.txt
 RUN pip install --no-cache-dir -r /requirements-airflow.txt


### PR DESCRIPTION
Install OpenJDK 17 in the Airflow Docker image so spark-submit can execute. JAVA_HOME is set to the installed JDK path.
