### PR TITLE
Fix silver DAG failing on days with no new data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,22 +7,22 @@
 
 ## Start all services
 up: .env
-	docker-compose up -d
+	docker compose up -d
 
 ## Stop all services
 down:
-	docker-compose down
+	docker compose down
 
 ## Restart all services
 restart: down up
 
 ## Tail logs for all containers (Ctrl-C to stop)
 logs:
-	docker-compose logs -f
+	docker compose logs -f
 
 ## Show container status
 ps:
-	docker-compose ps
+	docker compose ps
 
 ## Seed the source database with sample e-commerce data
 seed:
@@ -37,12 +37,12 @@ seed:
 
 ## Run dbt models
 dbt-run:
-	docker-compose exec airflow-webserver \
+	docker compose exec airflow-webserver \
 		dbt run --profiles-dir /opt/airflow/dbt --project-dir /opt/airflow/dbt
 
 ## Run dbt tests
 dbt-test:
-	docker-compose exec airflow-webserver \
+	docker compose exec airflow-webserver \
 		dbt test --profiles-dir /opt/airflow/dbt --project-dir /opt/airflow/dbt
 
 ## Register the Debezium CDC connector (run after `make up`)

--- a/spark/jobs/transform_customers.py
+++ b/spark/jobs/transform_customers.py
@@ -5,6 +5,7 @@ Uses Iceberg MERGE INTO for high-performance incremental dimension updates.
 
 import os
 import sys
+from pyspark.errors import AnalysisException
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, current_timestamp, trim, lower
 
@@ -21,7 +22,12 @@ def create_spark_session():
 def read_from_bronze(spark, date_path):
     bronze_path = f"s3a://bronze/customers_source/{date_path}/"
     print(f"Reading Customer Bronze layer from: {bronze_path}")
-    return spark.read.parquet(bronze_path)
+    try:
+        return spark.read.parquet(bronze_path)
+    except AnalysisException:
+        # Ingestion writes no files on days with zero new rows
+        print(f"No Bronze data at {bronze_path} — nothing to transform today.")
+        return None
 
 
 def transform_customers(df):
@@ -95,6 +101,8 @@ def main():
     try:
         print(f"Starting Spark Job: Customer Bronze to Silver — date: {date_str}")
         bronze_df = read_from_bronze(spark, formatted_date)
+        if bronze_df is None:
+            return
         silver_df = transform_customers(bronze_df)
         upsert_to_iceberg(spark, silver_df)
         print("Incremental Customer Spark Job Completed Successfully!")

--- a/spark/jobs/transform_order_items.py
+++ b/spark/jobs/transform_order_items.py
@@ -5,6 +5,7 @@ Uses Iceberg MERGE INTO for high-performance incremental transaction line-item u
 
 import os
 import sys
+from pyspark.errors import AnalysisException
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, current_timestamp
 
@@ -21,7 +22,12 @@ def create_spark_session():
 def read_from_bronze(spark, date_path):
     bronze_path = f"s3a://bronze/order_items_source/{date_path}/"
     print(f"Reading OrderItems Bronze layer from: {bronze_path}")
-    return spark.read.parquet(bronze_path)
+    try:
+        return spark.read.parquet(bronze_path)
+    except AnalysisException:
+        # Ingestion writes no files on days with zero new rows
+        print(f"No Bronze data at {bronze_path} — nothing to transform today.")
+        return None
 
 
 def transform_order_items(df):
@@ -87,6 +93,8 @@ def main():
     try:
         print(f"Starting Spark Job: OrderItems Bronze to Silver — date: {date_str}")
         bronze_df = read_from_bronze(spark, formatted_date)
+        if bronze_df is None:
+            return
         silver_df = transform_order_items(bronze_df)
         upsert_to_iceberg(spark, silver_df)
         print("Incremental OrderItems Spark Job Completed Successfully!")

--- a/spark/jobs/transform_orders.py
+++ b/spark/jobs/transform_orders.py
@@ -3,6 +3,7 @@ Spark Job: Transform Orders from Bronze to Silver (Elite Scalability)
 Uses Iceberg MERGE INTO for high-performance incremental upserts.
 """
 
+from pyspark.errors import AnalysisException
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, current_timestamp
 from pyspark.sql.types import DecimalType
@@ -28,7 +29,12 @@ def read_from_minio(spark, date):
     path = f"s3a://{bronze_bucket}/orders_source/{year}/{month}/{day}/"
 
     print(f"Reading Bronze layer from: {path}")
-    df = spark.read.parquet(path)
+    try:
+        df = spark.read.parquet(path)
+    except AnalysisException:
+        # Ingestion writes no files on days with zero new rows
+        print(f"No Bronze data at {path} — nothing to transform today.")
+        return None
     print(f"Loaded {df.count()} records from Bronze")
     return df
 
@@ -42,7 +48,7 @@ def transform_to_silver(df):
         .filter(col("customer_id").isNotNull()) \
         .filter(col("total_amount") > 0) \
         .filter(col("status").isNotNull()) \
-        .withColumn("total_amount", col("total_amount").cast(DecimalType(10, 2))) \
+        .withColumn("total_amount", col("total_amount").cast(DecimalType(18, 2))) \
         .withColumn("order_date", col("order_date").cast("timestamp")) \
         .withColumn("created_at", col("created_at").cast("timestamp")) \
         .withColumn("updated_at", col("updated_at").cast("timestamp")) \
@@ -114,6 +120,8 @@ def main():
 
     try:
         bronze_df = read_from_minio(spark, date)
+        if bronze_df is None:
+            return
         silver_df = transform_to_silver(bronze_df)
         upsert_to_iceberg(spark, silver_df)
         print("Incremental Spark Job Completed Successfully!")

--- a/spark/jobs/transform_products.py
+++ b/spark/jobs/transform_products.py
@@ -5,6 +5,7 @@ Uses Iceberg MERGE INTO for high-performance incremental catalog updates.
 
 import os
 import sys
+from pyspark.errors import AnalysisException
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, current_timestamp, trim, lower
 
@@ -21,7 +22,12 @@ def create_spark_session():
 def read_from_bronze(spark, date_path):
     bronze_path = f"s3a://bronze/products_source/{date_path}/"
     print(f"Reading Product Bronze layer from: {bronze_path}")
-    return spark.read.parquet(bronze_path)
+    try:
+        return spark.read.parquet(bronze_path)
+    except AnalysisException:
+        # Ingestion writes no files on days with zero new rows
+        print(f"No Bronze data at {bronze_path} — nothing to transform today.")
+        return None
 
 
 def transform_products(df):
@@ -92,6 +98,8 @@ def main():
     try:
         print(f"Starting Spark Job: Product Bronze to Silver — date: {date_str}")
         bronze_df = read_from_bronze(spark, formatted_date)
+        if bronze_df is None:
+            return
         silver_df = transform_products(bronze_df)
         upsert_to_iceberg(spark, silver_df)
         print("Incremental Product Spark Job Completed Successfully!")


### PR DESCRIPTION
Ingestion writes no bronze parquet when incremental extraction finds zero new rows, but still triggers `spark_transform_silver` — all four transform jobs crashed on the missing day path (`AnalysisException`), so the Spark DAG went red every quiet day. Each job now treats a missing Bronze path as a clean no-op and exits successfully.

Also folds in two touch-ups from the same review pass:
- `total_amount` cast widened from `Decimal(10,2)` to `Decimal(18,2)`, matching the source `NUMERIC(18,2)`
- Makefile switched from `docker-compose` (v1) to `docker compose` (v2) so targets work on plain Linux installs

Verified: ruff / py_compile / bandit clean; `pyspark.errors.AnalysisException` import confirmed against the pinned pyspark. The skip path can't be exercised without a live Spark cluster — the logic is a single try/except around the read, mirrored identically in all four jobs.