### PR TITLE
Make deploy.sh actually perform the documented daemon migration

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -224,12 +224,9 @@ kubectl logs -n etl <pod-name>    # read the logs
 ```
 
 ### Upgrading from an older deployment
-`deploy.sh` handles migrations automatically (it removes the retired cdc-sync-daemon and the old raw-manifest Trino before installing the Helm release). If you deployed before July 2026, also run once:
-```bash
-kubectl delete deployment cdc-sync-daemon -n etl --ignore-not-found
-```
+`deploy.sh` handles most migrations automatically: it removes the retired cdc-sync-daemon and the old raw-manifest Trino before installing the Helm release. Nothing to run by hand for those.
 
-Kafka storage moved from ephemeral to persistent volumes. Strimzi cannot change the storage type of a running cluster, so if your cluster predates this, delete the Kafka CR once before redeploying (in-flight messages are lost — they were on ephemeral storage anyway, and the CDC connector re-syncs):
+One migration it cannot do for you: Kafka storage moved from ephemeral to persistent volumes. Strimzi cannot change the storage type of a running cluster, so if your cluster predates this, delete the Kafka CR once before redeploying (in-flight messages are lost — they were on ephemeral storage anyway, and the CDC connector re-syncs):
 ```bash
 kubectl delete kafka etl-kafka -n etl --ignore-not-found
 bash k8s/deploy.sh   # recreates Kafka on persistent volumes

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The destination warehouse (`destdb`) is strictly organized:
 
 | Layer | Component |
 |---|---|
-| **Orchestration** | Apache Airflow 3.2 |
+| **Orchestration** | Apache Airflow 3.3 |
 | **CDC / Streaming** | Debezium 2.5 & Apache Kafka (KRaft) |
 | **Object Storage** | MinIO (S3-compatible) |
 | **Warehouse Transformation** | dbt-core (incremental models + tests) |

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -201,6 +201,10 @@ kubectl rollout status statefulset/spark-master -n $NAMESPACE --timeout=300s
 kubectl rollout status deployment/spark-worker -n $NAMESPACE --timeout=300s
 ok "Spark cluster is ready"
 
+# One-time migration: the CDC sync daemon was retired when ClickHouse became
+# the sole Pipe 3 consumer. Remove it if an older deployment left it running.
+kubectl delete deployment/cdc-sync-daemon -n $NAMESPACE --ignore-not-found
+
 info "Deploying Trino (lakehouse query engine) via the official Helm chart..."
 # One-time migration: remove the previous raw-manifest deployment if present
 kubectl delete deployment/trino service/trino configmap/trino-catalog \


### PR DESCRIPTION
Two small correctness fixes found while re-verifying the merged state end to end.

**1. deploy.sh didn't do what the guide said.** DEPLOY_GUIDE claimed `deploy.sh` removes the retired `cdc-sync-daemon` during migration, but the script only deleted the old raw-manifest Trino resources — the daemon cleanup existed purely as a manual step a reader had to spot and run. Added the idempotent `kubectl delete deployment/cdc-sync-daemon --ignore-not-found` so the documented behaviour is real, and removed the now-redundant manual instruction from the guide.

(I hit the concrete version of this locally: a stale `cdc-sync-daemon` container from July was still running on my machine and had to be removed by hand before testing. Same trap awaits anyone upgrading an older cluster.)

**2. Stale version claim.** README's tech-stack table said Apache Airflow 3.2; it's pinned at 3.3.0 in both `requirements.txt` and the runtime image. Worth correcting now that the Medium article is public and readers will check.

## Verification
- `shellcheck -S error` and `bash -n` clean on deploy.sh
- Full e2e on merged main before these changes: **9/9 pass**; source-vs-mirror revenue exact to the cent (diff 0.00)
- All other README version claims spot-checked against actual pins (Debezium 2.5, Spark 3.5, Iceberg 1.4, PostgreSQL 15, ClickHouse 24.8 — all correct)