### PR TITLE
docs: clean up markdown lint so the advisory check stops flagging PRs

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,24 @@
+{
+  // Markdown style rules for the repo's own docs.
+  //
+  // The CI job is advisory (continue-on-error), but its inline annotations
+  // showed up on every PR touching a .md file, which reads like a failure.
+  // Structural rules that affect rendering stay on; the two purely
+  // cosmetic ones below are off so the signal is meaningful.
+  "config": {
+    // Prose is not hard-wrapped at 80 columns — long lines keep diffs
+    // readable (one line per paragraph) and GitHub soft-wraps anyway.
+    "MD013": false,
+    // Tables use the compact `|---|` pipe style throughout; renders
+    // identically to the padded style this rule prefers.
+    "MD060": false
+  },
+  // Third-party and generated trees. CI lints a fresh checkout so most of
+  // these only exist locally, but ignoring them keeps a local run honest.
+  "ignores": [
+    "**/node_modules/**",
+    "**/.next/**",
+    "dbt-mcp/**",
+    "dbt/dbt_packages/**"
+  ]
+}

--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -25,6 +25,7 @@ One source database feeding three parallel pipelines, plus a query layer:
 Install these tools on your machine before starting.
 
 ### 1. kubectl
+
 ```bash
 # Mac
 brew install kubectl
@@ -40,6 +41,7 @@ chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 Verify: `kubectl version --client`
 
 ### 2. Helm
+
 ```bash
 # Mac
 brew install helm
@@ -54,20 +56,25 @@ curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 Verify: `helm version`
 
 ### 3. Docker
-Download and install from: **https://docs.docker.com/get-docker/**
+
+Download and install from: **<https://docs.docker.com/get-docker/>**
 
 Verify: `docker --version`
 
 ### 4. Docker Hub account (free)
-Needed to push the custom Airflow and dashboard images. Sign up at **https://hub.docker.com**, then:
+
+Needed to push the custom Airflow and dashboard images. Sign up at **<https://hub.docker.com>**, then:
+
 ```bash
 docker login
 ```
 
 ### 5. Kubernetes cluster access
+
 ```bash
 kubectl cluster-info
 ```
+
 You should see your cluster URL, not an error. If this fails, ask whoever manages your cluster for the kubeconfig file.
 
 ---
@@ -75,24 +82,29 @@ You should see your cluster URL, not an error. If this fails, ask whoever manage
 ## Deployment Steps
 
 ### Step 1 — Clone the repository
+
 ```bash
 git clone https://github.com/kalluripradeep/modern-etl-stack.git
 cd modern-etl-stack
 ```
 
 ### Step 2 — Generate credentials (recommended)
+
 ```bash
 bash k8s/generate-secrets.sh
 ```
+
 This writes `k8s/01-secrets.generated.yaml` (gitignored) with random passwords, and the deploy script picks it up automatically. **Save the printed passwords** — you need them for the dashboards in Step 6. Skipping this deploys well-known default credentials, acceptable only for a throwaway cluster.
 
 **Optional — enable the real AI assistant:** the AI dashboard runs in demo mode unless it has an Anthropic API key. Add it to the secret at any time (before or after deploying):
+
 ```bash
 kubectl -n etl patch secret etl-secrets -p '{"stringData":{"ANTHROPIC_API_KEY":"sk-ant-..."}}'
 kubectl -n etl rollout restart deployment/data-dashboard
 ```
 
 ### Step 3 — Run the deploy script
+
 ```bash
 bash k8s/deploy.sh
 ```
@@ -106,12 +118,14 @@ The script asks three questions:
 It then deploys everything: databases, Strimzi Kafka + Debezium connector, ClickHouse, MinIO (with bronze/silver buckets), Spark, Trino (Helm), Airflow (Helm), the AI dashboard, and the monitoring stack. First run takes about **10–15 minutes** (Kafka cluster startup is the slow part).
 
 ### Step 4 — Wait for all pods to be Running
+
 ```bash
 kubectl get pods -n etl -w
 ```
 
 Wait until every pod shows `Running`/`Completed`, then Ctrl+C. Expect roughly:
-```
+
+```text
 NAME                                READY   STATUS
 airflow-api-server-xxx              1/1     Running
 airflow-scheduler-xxx               1/1     Running
@@ -136,12 +150,14 @@ trino-worker-xxx (x2)               1/1     Running
 ```
 
 ### Step 5 — Run the end-to-end test
+
 ```bash
 bash scripts/test_e2e.sh
 ```
 
 This port-forwards the services, seeds 200 orders, runs the extract → MinIO → warehouse pipeline, fires live transactions (updates, cancellations, hard deletes), and verifies the ClickHouse mirror caught every change. Expected ending:
-```
+
+```text
   ✓  Seeded 200 orders into postgres-source
   ✓  Validation passed
   ✓  Uploaded 4 parquet file(s) to MinIO
@@ -158,6 +174,7 @@ This port-forwards the services, seeds 200 orders, runs the extract → MinIO �
 ### Step 6 — Open the dashboards
 
 Get your node IP:
+
 ```bash
 kubectl get nodes -o wide   # EXTERNAL-IP column; use INTERNAL-IP if blank
 ```
@@ -174,6 +191,7 @@ kubectl get nodes -o wide   # EXTERNAL-IP column; use INTERNAL-IP if blank
 Credentials come from `k8s/01-secrets.generated.yaml` if you ran Step 2, otherwise from the defaults in `k8s/01-secrets.yaml`.
 
 **Trino** (no NodePort — port-forward to query the lakehouse):
+
 ```bash
 kubectl port-forward svc/trino 8080:8080 -n etl
 # then http://localhost:8080 (any username), e.g.:
@@ -181,6 +199,7 @@ kubectl port-forward svc/trino 8080:8080 -n etl
 ```
 
 **ClickHouse** (query the real-time mirror):
+
 ```bash
 kubectl exec -n etl clickhouse-0 -- clickhouse-client --user <CLICKHOUSE_USER> --password <CLICKHOUSE_PASSWORD> \
   -q "SELECT status, count() FROM mirror.orders_current GROUP BY status"
@@ -204,29 +223,35 @@ To deliver alerts (DAG failures, CDC lag, stale data, revenue anomalies), add a 
 ## Troubleshooting
 
 ### docker push fails
+
 ```bash
 docker login   # then retry
 ```
 
 ### kubectl cluster-info fails
+
 ```bash
 export KUBECONFIG=/path/to/your/kubeconfig
 kubectl cluster-info
 ```
 
 ### Pods stuck in Pending
+
 Usually storage: check `kubectl describe pod <pod> -n etl` for PVC events, and confirm the StorageClass you accepted in Step 3 exists (`kubectl get sc`).
 
 ### A test step fails
+
 ```bash
 kubectl get pods -n etl           # find the pod name
 kubectl logs -n etl <pod-name>    # read the logs
 ```
 
 ### Upgrading from an older deployment
+
 `deploy.sh` handles most migrations automatically: it removes the retired cdc-sync-daemon and the old raw-manifest Trino before installing the Helm release. Nothing to run by hand for those.
 
 One migration it cannot do for you: Kafka storage moved from ephemeral to persistent volumes. Strimzi cannot change the storage type of a running cluster, so if your cluster predates this, delete the Kafka CR once before redeploying (in-flight messages are lost — they were on ephemeral storage anyway, and the CDC connector re-syncs):
+
 ```bash
 kubectl delete kafka etl-kafka -n etl --ignore-not-found
 bash k8s/deploy.sh   # recreates Kafka on persistent volumes
@@ -236,7 +261,7 @@ bash k8s/deploy.sh   # recreates Kafka on persistent volumes
 
 ## Quick Reference
 
-```
+```text
 INSTALL   kubectl + helm + docker + docker login
 CLONE     git clone https://github.com/kalluripradeep/modern-etl-stack.git
 SECRETS   bash k8s/generate-secrets.sh

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A comprehensive ETL stack demonstrating the integration of open-source data engi
 
 📄 The full design rationale is in the accompanying paper: [Data to Analytics Pipeline — Proof of Concept](https://github.com/kalluripradeep/modern-etl-stack/raw/main/docs/Data-to-Analytics-Pipeline-POC.pdf) (downloads the PDF)
 
-```
+```text
                          ┌──► PIPE 3 · Real-Time Analytics (seconds)
                          │     WAL → Debezium → Kafka → ClickHouse mirror.* (column store)
                          │
@@ -28,15 +28,19 @@ All three pipelines run in parallel from the same source. Pipes 1 and 3 are full
 ## Data Pipelines
 
 ### 1. Analytical Warehouse — Batch Analysis
+
 Airflow extracts snapshots from the operational database in chunked micro-batches, lands them in the `raw` schema of the destination warehouse, and dbt transforms them into cleaned (`int`) and presentation (`prs`) layers. Best for business reporting, BI tools, and any workload where daily freshness is enough. Simple to deploy and debug, minimal infrastructure.
 
 ### 2. Lakehouse — Big Historical Data, Many Query Engines
+
 The same ingestion run writes parquet files to MinIO (bronze). Spark jobs clean and MERGE them into **Apache Iceberg** tables (silver), and **Trino** exposes those tables over ANSI SQL (`iceberg.lake.*`) to BI tools, notebooks, and the AI assistant. The Iceberg catalog is a JDBC catalog stored in the destination Postgres, so Spark and Trino always see the same tables. On Kubernetes, Trino is deployed via the official Helm chart (coordinator plus workers — scale with `server.workers` in `k8s/trino/helm-values.yaml`). Designed for data volumes that would be too expensive to keep in an operational database.
 
 ### 3. Real-Time Analytics — Streaming CDC into ClickHouse
+
 Debezium captures every insert/update/delete from the source WAL into Kafka, and **ClickHouse** consumes the topics with its built-in Kafka engine, materializing them into columnar tables (query the `mirror.*_current` views). Seconds-level freshness for live dashboards and operational monitoring, without touching the source database's performance. Kafka in the middle buys durability and replay — the mirror can be rebuilt from the retained log — and lets future consumers subscribe to the same change stream without adding replication slots on the source.
 
 ### AI Data Assistant
+
 A Next.js dashboard with an agentic analyst: it introspects the schemas of all three stores, decides which engine fits the question (warehouse, lakehouse via Trino, or the ClickHouse mirror), runs read-only SQL with automatic error-retry, and answers in plain language. Runs in demo mode without an API key; add an Anthropic API key to enable it, and set `DASHBOARD_AUTH_PASSWORD` to require a login.
 
 ## Adding a Source Table
@@ -68,13 +72,14 @@ Prometheus scrapes Airflow (via statsd), Kafka consumer lag (kafka-exporter), Mi
 
 | Service | Local URL |
 |---|---|
-| Grafana dashboards | http://localhost:3000 |
-| Prometheus | http://localhost:9090 |
-| Alertmanager | http://localhost:9095 |
+| Grafana dashboards | <http://localhost:3000> |
+| Prometheus | <http://localhost:9090> |
+| Alertmanager | <http://localhost:9095> |
 
 ## Database Schema Structure
 
 The destination warehouse (`destdb`) is strictly organized:
+
 - **`raw`:** batch snapshots straight from the source (`*_source` tables).
 - **`int`:** cleaned, deduplicated integration layer (`*_clean` tables).
 - **`prs`:** presentation views for BI (`prs.v_daily_revenue`, …). Only this schema is exposed to BI tools.
@@ -118,15 +123,15 @@ Kubernetes: `bash k8s/generate-secrets.sh && bash k8s/deploy.sh` (see [DEPLOY_GU
 
 | Service | Local URL | Credentials (from `.env`) |
 |---|---|---|
-| **Airflow UI** | http://localhost:8080 | admin / admin |
-| **AI Dashboard** | http://localhost:3001 *(run `npm run dev -- -p 3001` in `ui/`; 3000 is Grafana's)* | open unless `DASHBOARD_AUTH_PASSWORD` set |
-| **Trino UI** | http://localhost:8082 | any username |
-| **ClickHouse** | http://localhost:8123 | `CLICKHOUSE_USER` / `CLICKHOUSE_PASSWORD` |
-| **MinIO Console** | http://localhost:9001 | `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` |
-| **Kafka UI** | http://localhost:8001 | `KAFKA_UI_USER` / `KAFKA_UI_PASSWORD` |
-| **Metabase** | http://localhost:3030 | (setup required) |
-| **Spark Master** | http://localhost:8081 | — |
-| **Grafana** | http://localhost:3000 *(compose)* | `GRAFANA_ADMIN_USER` / password |
+| **Airflow UI** | <http://localhost:8080> | admin / admin |
+| **AI Dashboard** | <http://localhost:3001> *(run `npm run dev -- -p 3001` in `ui/`; 3000 is Grafana's)* | open unless `DASHBOARD_AUTH_PASSWORD` set |
+| **Trino UI** | <http://localhost:8082> | any username |
+| **ClickHouse** | <http://localhost:8123> | `CLICKHOUSE_USER` / `CLICKHOUSE_PASSWORD` |
+| **MinIO Console** | <http://localhost:9001> | `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` |
+| **Kafka UI** | <http://localhost:8001> | `KAFKA_UI_USER` / `KAFKA_UI_PASSWORD` |
+| **Metabase** | <http://localhost:3030> | (setup required) |
+| **Spark Master** | <http://localhost:8081> | — |
+| **Grafana** | <http://localhost:3000> *(compose)* | `GRAFANA_ADMIN_USER` / password |
 
 ## Orchestration & Pipeline Details
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,3 +1,5 @@
+# AI Data Assistant (Dashboard UI)
+
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
 ## Getting Started


### PR DESCRIPTION
The `markdown-lint` job is advisory (`continue-on-error: true`) and has always concluded green — but it annotated every PR touching a `.md` file with inline red *"Check failure on line R27"* markers. That reads like a broken build and trains the eye to ignore CI. This makes the docs actually clean so the annotations stop.

## Approach

**Config** (`.markdownlint-cli2.jsonc`) turns off the two purely cosmetic rules and ignores third-party trees:

| Rule | Why off |
|---|---|
| MD013 line-length | Prose isn't hard-wrapped at 80 columns; one line per paragraph keeps diffs readable and GitHub soft-wraps anyway |
| MD060 table-column-style | The compact `\|---\|` pipe style used throughout renders identically to the padded style |

**Fixes** for the 60 structural findings that remained — these affect the source, not just taste:

- blank lines around headings, fences and lists (MD022/MD031/MD032)
- bare URLs wrapped as proper `<autolinks>` (MD034)
- a `text` language tag on the four plain-text blocks — architecture diagram, pod list, expected test output, quick reference (MD040)
- an H1 on the dashboard README, which was still the bare `create-next-app` scaffold text (MD041)

## Verification

- **Content is unchanged.** Normalising whitespace and autolink brackets, the before/after text of `README.md` and `DEPLOY_GUIDE.md` is identical line for line (127 and 194 lines respectively, programmatically compared) — the auto-fixer only inserted blank lines and `<>` wrappers.
- `markdownlint-cli2 "**/*.md"` — the exact glob CI runs — reports **0 issues across 4 files**, exit 0.

## Note

I left `continue-on-error: true` in place. Docs style shouldn't block a merge, and `markdownlint-cli2-action@v15` pulls new markdownlint versions that periodically add rules (MD060 is itself recent) — the same unpinned-linter drift that broke `lint-python` yesterday. Happy to make it blocking if you'd rather enforce it.