### PR TITLE
Hourly batch cadence, and the bronze fix it requires

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -222,17 +222,7 @@ To deliver alerts (DAG failures, CDC lag, stale data, revenue anomalies), add a 
 
 Step 5 proves the pipelines work once. To watch a continuous stream of new records land in all three destinations, generate live traffic against the source.
 
-**First, speed up the batch cadence.** Pipe 3 (CDC → ClickHouse) is continuous and needs nothing. Pipes 1 and 2 run `@hourly`, which is the right production cadence but still slow to watch. For a test run, set a short cron and restart the schedulers:
-
-```bash
-kubectl patch configmap etl-env -n etl \
-  -p '{"data":{"INGEST_SCHEDULE":"*/15 * * * *","SILVER_SCHEDULE":"*/15 * * * *"}}'
-kubectl rollout restart deployment/airflow-scheduler deployment/airflow-dag-processor -n etl
-```
-
-Put them back to `@hourly` when you are done.
-
-**Then generate traffic.** Port-forward the source and run the generator — it only ever appends and updates, so CDC, the mirror and the batch high-water mark all stay valid while it runs:
+**Generate traffic.** Port-forward the source and run the generator — it only ever appends and updates, so CDC, the mirror and the batch high-water mark all stay valid while it runs:
 
 ```bash
 kubectl port-forward svc/postgres-source 5432:5432 -n etl
@@ -243,13 +233,15 @@ python scripts/simulate_live_traffic.py --rate 5 --interval 3
 
 Leave it running and watch each destination:
 
-| Pipeline | Where to look | Expected lag |
+| Pipeline | Where to look | When it moves |
 |---|---|---|
 | **3 · Real-time mirror** | `mirror.orders_current` in ClickHouse (command above) — rerun it and the count climbs | seconds |
-| **1 · Warehouse** | `raw.orders_source`, then `int`/`gold` after dbt runs; Airflow UI shows each run | next scheduled run |
-| **2 · Lakehouse** | `iceberg.lake.orders` via Trino | after the silver DAG follows ingestion |
+| **1 · Warehouse** | `raw.orders_source`, then `int`/`gold` after dbt runs | on the hourly run |
+| **2 · Lakehouse** | `iceberg.lake.orders` via Trino | on the hourly run, after the silver DAG follows ingestion |
 
-The source count and the ClickHouse count should track each other continuously. The warehouse and lakehouse catch up in steps, one batch per scheduled run — that difference **is** the architecture, and watching the three side by side is the clearest demonstration of it.
+The source count and the ClickHouse count should track each other continuously. The warehouse and lakehouse catch up in steps, one batch per run — that difference **is** the architecture, and watching the three side by side is the clearest demonstration of it.
+
+The batch DAGs run hourly, so leave the generator going and check back. To see a batch cycle immediately instead of waiting, trigger `ingest_source_to_bronze` from the Airflow UI (`http://NODE_IP:30880`) — it runs on demand and the silver DAG follows it.
 
 > Do not use `make seed` / `generate_ecommerce.py` for this: that script drops and recreates the source tables, which breaks the replication slot mid-test and leaves stale rows in the mirror. `simulate_live_traffic.py` is the non-destructive one.
 

--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -218,6 +218,41 @@ A **Data Platform Health** dashboard (pipeline runs, CDC lag, source freshness, 
 
 To deliver alerts (DAG failures, CDC lag, stale data, revenue anomalies), add a Slack/email receiver in the `alertmanager-config` ConfigMap.
 
+### Step 8 — Watch live data flow through all three pipelines
+
+Step 5 proves the pipelines work once. To watch a continuous stream of new records land in all three destinations, generate live traffic against the source.
+
+**First, speed up the batch cadence.** Pipe 3 (CDC → ClickHouse) is continuous and needs nothing, but Pipes 1 and 2 run `@daily` out of the box — you would wait a day to see them move. For a test run, set a short cron and restart the schedulers:
+
+```bash
+kubectl patch configmap etl-env -n etl \
+  -p '{"data":{"INGEST_SCHEDULE":"*/15 * * * *","SILVER_SCHEDULE":"*/15 * * * *"}}'
+kubectl rollout restart deployment/airflow-scheduler deployment/airflow-dag-processor -n etl
+```
+
+Put them back to `@daily` when you are done.
+
+**Then generate traffic.** Port-forward the source and run the generator — it only ever appends and updates, so CDC, the mirror and the batch high-water mark all stay valid while it runs:
+
+```bash
+kubectl port-forward svc/postgres-source 5432:5432 -n etl
+# in another terminal, from the repo root:
+pip install psycopg2-binary
+python scripts/simulate_live_traffic.py --rate 5 --interval 3
+```
+
+Leave it running and watch each destination:
+
+| Pipeline | Where to look | Expected lag |
+|---|---|---|
+| **3 · Real-time mirror** | `mirror.orders_current` in ClickHouse (command above) — rerun it and the count climbs | seconds |
+| **1 · Warehouse** | `raw.orders_source`, then `int`/`gold` after dbt runs; Airflow UI shows each run | next scheduled run |
+| **2 · Lakehouse** | `iceberg.lake.orders` via Trino | after the silver DAG follows ingestion |
+
+The source count and the ClickHouse count should track each other continuously. The warehouse and lakehouse catch up in steps, one batch per scheduled run — that difference **is** the architecture, and watching the three side by side is the clearest demonstration of it.
+
+> Do not use `make seed` / `generate_ecommerce.py` for this: that script drops and recreates the source tables, which breaks the replication slot mid-test and leaves stale rows in the mirror. `simulate_live_traffic.py` is the non-destructive one.
+
 ---
 
 ## Troubleshooting

--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -222,7 +222,7 @@ To deliver alerts (DAG failures, CDC lag, stale data, revenue anomalies), add a 
 
 Step 5 proves the pipelines work once. To watch a continuous stream of new records land in all three destinations, generate live traffic against the source.
 
-**First, speed up the batch cadence.** Pipe 3 (CDC → ClickHouse) is continuous and needs nothing, but Pipes 1 and 2 run `@daily` out of the box — you would wait a day to see them move. For a test run, set a short cron and restart the schedulers:
+**First, speed up the batch cadence.** Pipe 3 (CDC → ClickHouse) is continuous and needs nothing. Pipes 1 and 2 run `@hourly`, which is the right production cadence but still slow to watch. For a test run, set a short cron and restart the schedulers:
 
 ```bash
 kubectl patch configmap etl-env -n etl \
@@ -230,7 +230,7 @@ kubectl patch configmap etl-env -n etl \
 kubectl rollout restart deployment/airflow-scheduler deployment/airflow-dag-processor -n etl
 ```
 
-Put them back to `@daily` when you are done.
+Put them back to `@hourly` when you are done.
 
 **Then generate traffic.** Port-forward the source and run the generator — it only ever appends and updates, so CDC, the mirror and the batch high-water mark all stay valid while it runs:
 

--- a/airflow/dags/ingest_source_to_bronze.py
+++ b/airflow/dags/ingest_source_to_bronze.py
@@ -64,7 +64,10 @@ dag = DAG(
     'ingest_source_to_bronze',
     default_args=default_args,
     description='Extract all source tables from postgres to data lake (Bronze)',
-    schedule='@daily',
+    # Daily by default. Set INGEST_SCHEDULE (e.g. '*/15 * * * *') to run the
+    # batch and lakehouse pipelines more often — useful when watching records
+    # flow end to end without waiting a day for the next run.
+    schedule=os.environ.get('INGEST_SCHEDULE', '@daily'),
     catchup=False,
     tags=['etl', 'bronze', 'multi-table'],
 )

--- a/airflow/dags/ingest_source_to_bronze.py
+++ b/airflow/dags/ingest_source_to_bronze.py
@@ -66,8 +66,8 @@ dag = DAG(
     description='Extract all source tables from postgres to data lake (Bronze)',
     # Hourly by default — extraction is incremental (high-water mark on the
     # cursor column), so a shorter cadence just means fewer rows per run and
-    # fresher warehouse data. Override with INGEST_SCHEDULE (e.g. '@daily'
-    # to go back to one run a day, or '*/15 * * * *' for a live demo).
+    # fresher warehouse data. Override with INGEST_SCHEDULE if an environment
+    # needs a different cadence (any Airflow schedule expression).
     schedule=os.environ.get('INGEST_SCHEDULE', '@hourly'),
     catchup=False,
     # Never let a slow run overlap the next one: concurrent runs would race

--- a/airflow/dags/ingest_source_to_bronze.py
+++ b/airflow/dags/ingest_source_to_bronze.py
@@ -64,11 +64,15 @@ dag = DAG(
     'ingest_source_to_bronze',
     default_args=default_args,
     description='Extract all source tables from postgres to data lake (Bronze)',
-    # Daily by default. Set INGEST_SCHEDULE (e.g. '*/15 * * * *') to run the
-    # batch and lakehouse pipelines more often — useful when watching records
-    # flow end to end without waiting a day for the next run.
-    schedule=os.environ.get('INGEST_SCHEDULE', '@daily'),
+    # Hourly by default — extraction is incremental (high-water mark on the
+    # cursor column), so a shorter cadence just means fewer rows per run and
+    # fresher warehouse data. Override with INGEST_SCHEDULE (e.g. '@daily'
+    # to go back to one run a day, or '*/15 * * * *' for a live demo).
+    schedule=os.environ.get('INGEST_SCHEDULE', '@hourly'),
     catchup=False,
+    # Never let a slow run overlap the next one: concurrent runs would race
+    # on the same raw tables and high-water mark.
+    max_active_runs=1,
     tags=['etl', 'bronze', 'multi-table'],
 )
 
@@ -83,6 +87,14 @@ def extract_and_load_table(table_name, **kwargs):
     cursor_col = config.get('cursor_column')
     logical_date = kwargs.get('logical_date', datetime.now())
     date_prefix = logical_date.strftime("%Y/%m/%d")
+    # Bronze objects stay in a daily folder (that is what the Spark jobs read),
+    # but the filename carries the run timestamp. Without it every run of the
+    # same day writes part-00000.parquet and overwrites the previous one —
+    # harmless at @daily, silent data loss for the lakehouse at any faster
+    # cadence, since each incremental run only holds its own new rows.
+    # A retry of the same run reuses its stamp and overwrites itself, which
+    # is the idempotent behaviour we want.
+    run_stamp = logical_date.strftime("%Y%m%dT%H%M%S")
 
     chunk_size = int(os.environ.get('ETL_CHUNK_SIZE', 10000))
     bucket_name = 'bronze'
@@ -152,7 +164,7 @@ def extract_and_load_table(table_name, **kwargs):
                         raise ValueError(f"Data quality error: Null PKs in {table_name} at {file_path}")
 
                     # Upload to MinIO
-                    object_name = f'{table_name}_source/{date_prefix}/part-{idx:05d}.parquet'
+                    object_name = f'{table_name}_source/{date_prefix}/part-{run_stamp}-{idx:05d}.parquet'
                     s3_hook.load_file(filename=file_path, key=object_name, bucket_name=bucket_name, replace=True)
 
                     # Upsert into DWH

--- a/airflow/dags/spark_transform_silver.py
+++ b/airflow/dags/spark_transform_silver.py
@@ -40,8 +40,11 @@ with DAG(
     description='Spark Batch Processing - Bronze to Silver (Iceberg)',
     # Also triggered by ingest_source_to_bronze on completion; this schedule
     # is the independent fallback. Override with SILVER_SCHEDULE.
-    schedule=os.environ.get('SILVER_SCHEDULE', '@daily'),
+    schedule=os.environ.get('SILVER_SCHEDULE', '@hourly'),
     catchup=False,
+    # Spark jobs are long-running; overlapping runs would MERGE into the same
+    # Iceberg tables concurrently.
+    max_active_runs=1,
     tags=['spark', 'iceberg', 'silver', 'scalability', 'compaction'],
 ) as dag:
 
@@ -93,9 +96,13 @@ with DAG(
     maintenance_task = BashOperator(
         task_id='iceberg_maintenance',
         bash_command=(
-            'if [ "$(date -d \'{{ ds }}\' +%u)" = "7" ]; then '
+            # Gate on weekday AND hour (%u%H == "700"): with an hourly schedule
+            # the date alone is the same for all 24 Sunday runs, which would
+            # compact 24 times instead of once. -u pins the comparison to UTC
+            # (Airflow's logical time) so it cannot drift with container TZ.
+            'if [ "$(date -u -d \'{{ ts }}\' +%u%H)" = "700" ]; then '
             + get_spark_submit_command('Iceberg-Maintenance', '/opt/spark-jobs/iceberg_maintenance.py')
-            + '; else echo "Skipping Iceberg maintenance — runs on Sundays only"; fi'
+            + '; else echo "Skipping Iceberg maintenance — runs Sundays at 00:00 only"; fi'
         ),
         # Run only on Sundays to optimize storage after weekly activity
         execution_timeout=timedelta(hours=2),

--- a/airflow/dags/spark_transform_silver.py
+++ b/airflow/dags/spark_transform_silver.py
@@ -38,7 +38,9 @@ with DAG(
     'spark_transform_silver',
     default_args=default_args,
     description='Spark Batch Processing - Bronze to Silver (Iceberg)',
-    schedule='@daily',
+    # Also triggered by ingest_source_to_bronze on completion; this schedule
+    # is the independent fallback. Override with SILVER_SCHEDULE.
+    schedule=os.environ.get('SILVER_SCHEDULE', '@daily'),
     catchup=False,
     tags=['spark', 'iceberg', 'silver', 'scalability', 'compaction'],
 ) as dag:

--- a/k8s/02-configmaps.yaml
+++ b/k8s/02-configmaps.yaml
@@ -137,10 +137,9 @@ data:
   KAFKA_CONNECT_URL: "http://kafka-connect-0.kafka-connect.etl.svc.cluster.local:8083"
   BRONZE_BUCKET: "bronze"
   SILVER_BUCKET: "silver"
-  # Batch cadence. Hourly in production — extraction is incremental, so a
-  # shorter cadence just means fewer rows per run and fresher data. Use
-  # "@daily" to go back to one run a day, or a cron such as "*/15 * * * *"
-  # when watching records flow end to end.
+  # Batch cadence for the warehouse and lakehouse pipelines. Extraction is
+  # incremental, so a shorter cadence just means fewer rows per run and
+  # fresher data. Accepts any Airflow schedule expression.
   INGEST_SCHEDULE: "@hourly"
   SILVER_SCHEDULE: "@hourly"
   # Scale these up for large datasets (50GB+)

--- a/k8s/02-configmaps.yaml
+++ b/k8s/02-configmaps.yaml
@@ -137,6 +137,11 @@ data:
   KAFKA_CONNECT_URL: "http://kafka-connect-0.kafka-connect.etl.svc.cluster.local:8083"
   BRONZE_BUCKET: "bronze"
   SILVER_BUCKET: "silver"
+  # Batch cadence. "@daily" is the production default; set a cron such as
+  # "*/15 * * * *" to watch records flow through the batch and lakehouse
+  # pipelines without waiting for the next daily run.
+  INGEST_SCHEDULE: "@daily"
+  SILVER_SCHEDULE: "@daily"
   # Scale these up for large datasets (50GB+)
   ETL_CHUNK_SIZE: "10000"
   SPARK_EXECUTOR_MEMORY: "2g"

--- a/k8s/02-configmaps.yaml
+++ b/k8s/02-configmaps.yaml
@@ -137,11 +137,12 @@ data:
   KAFKA_CONNECT_URL: "http://kafka-connect-0.kafka-connect.etl.svc.cluster.local:8083"
   BRONZE_BUCKET: "bronze"
   SILVER_BUCKET: "silver"
-  # Batch cadence. "@daily" is the production default; set a cron such as
-  # "*/15 * * * *" to watch records flow through the batch and lakehouse
-  # pipelines without waiting for the next daily run.
-  INGEST_SCHEDULE: "@daily"
-  SILVER_SCHEDULE: "@daily"
+  # Batch cadence. Hourly in production — extraction is incremental, so a
+  # shorter cadence just means fewer rows per run and fresher data. Use
+  # "@daily" to go back to one run a day, or a cron such as "*/15 * * * *"
+  # when watching records flow end to end.
+  INGEST_SCHEDULE: "@hourly"
+  SILVER_SCHEDULE: "@hourly"
   # Scale these up for large datasets (50GB+)
   ETL_CHUNK_SIZE: "10000"
   SPARK_EXECUTOR_MEMORY: "2g"

--- a/k8s/airflow/helm-values.yaml
+++ b/k8s/airflow/helm-values.yaml
@@ -86,6 +86,16 @@ extraEnv: |
       configMapKeyRef:
         name: etl-env
         key: ETL_CHUNK_SIZE
+  - name: INGEST_SCHEDULE
+    valueFrom:
+      configMapKeyRef:
+        name: etl-env
+        key: INGEST_SCHEDULE
+  - name: SILVER_SCHEDULE
+    valueFrom:
+      configMapKeyRef:
+        name: etl-env
+        key: SILVER_SCHEDULE
   - name: SPARK_EXECUTOR_MEMORY
     valueFrom:
       configMapKeyRef:

--- a/scripts/simulate_live_traffic.py
+++ b/scripts/simulate_live_traffic.py
@@ -1,0 +1,192 @@
+"""Continuously generate live traffic on the source database.
+
+Unlike sample-data/generate_ecommerce.py (which DROPs and recreates the
+tables, breaking CDC continuity), this only ever appends and updates, so
+the Debezium slot, the ClickHouse mirror and the batch high-water mark all
+stay valid while it runs. Use it to watch records flow through all three
+pipelines end to end.
+
+Each tick places a few new orders (with line items), advances the status of
+some existing ones, and occasionally cancels or deletes one — enough to
+exercise inserts, updates and deletes in the CDC stream.
+
+Usage (from the repo root):
+    python scripts/simulate_live_traffic.py                  # 3 orders every 5s, forever
+    python scripts/simulate_live_traffic.py --rate 10 --interval 2
+    python scripts/simulate_live_traffic.py --duration 15    # stop after 15 minutes
+    python scripts/simulate_live_traffic.py --once           # a single tick, then exit
+
+Against Kubernetes, port-forward the source first:
+    kubectl port-forward svc/postgres-source 5432:5432 -n etl
+"""
+
+import argparse
+import os
+import random
+import signal
+import sys
+import time
+from datetime import datetime
+
+import psycopg2
+
+SOURCE = {
+    'host': os.environ.get('SOURCE_DB_HOST', 'localhost'),
+    'port': int(os.environ.get('SOURCE_DB_PORT', 5432)),
+    'database': os.environ.get('SOURCE_DB_NAME', 'sourcedb'),
+    'user': os.environ.get('SOURCE_DB_USER', 'sourceuser'),
+    'password': os.environ.get('SOURCE_DB_PASSWORD', 'sourcepass'),
+}
+
+STATUSES = ['pending', 'processing', 'shipped', 'delivered']
+_running = True
+
+
+def _stop(signum, frame):
+    global _running
+    _running = False
+    print("\n  stopping after this tick…")
+
+
+def load_reference_data(cur):
+    """Existing customers and products to reference — keeps FKs valid."""
+    cur.execute("SELECT customer_id FROM customers")
+    customers = [r[0] for r in cur.fetchall()]
+    cur.execute("SELECT product_id, price FROM products")
+    products = cur.fetchall()
+    if not customers or not products:
+        sys.exit("No customers/products in the source. Run `make seed` once first.")
+    return customers, products
+
+
+def place_orders(cur, customers, products, count):
+    """Insert `count` new orders, each with 1-3 line items."""
+    for _ in range(count):
+        cur.execute(
+            "INSERT INTO orders (customer_id, order_date, total_amount, status) "
+            "VALUES (%s, CURRENT_TIMESTAMP, 0, 'pending') RETURNING order_id",
+            (random.choice(customers),),
+        )
+        order_id = cur.fetchone()[0]
+
+        total = 0
+        for _ in range(random.randint(1, 3)):
+            product_id, price = random.choice(products)
+            qty = random.randint(1, 3)
+            total += float(price) * qty
+            cur.execute(
+                "INSERT INTO order_items (order_id, product_id, quantity, unit_price) "
+                "VALUES (%s, %s, %s, %s)",
+                (order_id, product_id, qty, price),
+            )
+
+        # Keep the order total equal to the sum of its lines, so the gold
+        # layer's fact/order reconciliation stays exact.
+        cur.execute(
+            "UPDATE orders SET total_amount = %s, updated_at = CURRENT_TIMESTAMP "
+            "WHERE order_id = %s",
+            (round(total, 2), order_id),
+        )
+    return count
+
+
+def advance_statuses(cur, count):
+    """Move some recent orders along their lifecycle (UPDATE events)."""
+    cur.execute(
+        "SELECT order_id FROM orders WHERE status <> 'cancelled' "
+        "ORDER BY order_id DESC LIMIT 200"
+    )
+    ids = [r[0] for r in cur.fetchall()]
+    if not ids:
+        return 0
+    for oid in random.sample(ids, min(count, len(ids))):
+        cur.execute(
+            "UPDATE orders SET status = %s, updated_at = CURRENT_TIMESTAMP "
+            "WHERE order_id = %s",
+            (random.choice(STATUSES), oid),
+        )
+    return min(count, len(ids))
+
+
+def cancel_order(cur):
+    """Cancel one recent order (UPDATE event)."""
+    cur.execute(
+        "SELECT order_id FROM orders WHERE status <> 'cancelled' "
+        "ORDER BY random() LIMIT 1"
+    )
+    row = cur.fetchone()
+    if not row:
+        return 0
+    cur.execute(
+        "UPDATE orders SET status = 'cancelled', updated_at = CURRENT_TIMESTAMP "
+        "WHERE order_id = %s",
+        (row[0],),
+    )
+    return 1
+
+
+def delete_order(cur):
+    """Hard-delete one cancelled order (DELETE event — tests tombstones)."""
+    cur.execute(
+        "SELECT order_id FROM orders WHERE status = 'cancelled' "
+        "ORDER BY random() LIMIT 1"
+    )
+    row = cur.fetchone()
+    if not row:
+        return 0
+    cur.execute("DELETE FROM order_items WHERE order_id = %s", (row[0],))
+    cur.execute("DELETE FROM orders WHERE order_id = %s", (row[0],))
+    return 1
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument('--rate', type=int, default=3, help='new orders per tick (default 3)')
+    p.add_argument('--interval', type=float, default=5.0, help='seconds between ticks (default 5)')
+    p.add_argument('--duration', type=float, default=0, help='minutes to run; 0 = until Ctrl-C')
+    p.add_argument('--once', action='store_true', help='run a single tick and exit')
+    args = p.parse_args()
+
+    signal.signal(signal.SIGINT, _stop)
+
+    conn = psycopg2.connect(**SOURCE)
+    conn.autocommit = True
+    cur = conn.cursor()
+    customers, products = load_reference_data(cur)
+
+    print(f"Live traffic → {SOURCE['host']}:{SOURCE['port']}/{SOURCE['database']}")
+    print(f"  {args.rate} new order(s) every {args.interval}s "
+          f"({'single tick' if args.once else 'Ctrl-C to stop'})\n")
+
+    deadline = time.time() + args.duration * 60 if args.duration else None
+    placed = updated = cancelled = deleted = ticks = 0
+
+    while _running:
+        ticks += 1
+        placed += place_orders(cur, customers, products, args.rate)
+        updated += advance_statuses(cur, max(1, args.rate // 2))
+        if ticks % 4 == 0:
+            cancelled += cancel_order(cur)
+        if ticks % 10 == 0:
+            deleted += delete_order(cur)
+
+        cur.execute("SELECT count(*) FROM orders")
+        total_orders = cur.fetchone()[0]
+        print(f"  [{datetime.now():%H:%M:%S}] tick {ticks:>4} | "
+              f"+{placed} placed  ~{updated} updated  "
+              f"x{cancelled} cancelled  -{deleted} deleted | "
+              f"source now holds {total_orders} orders")
+
+        if args.once or (deadline and time.time() >= deadline):
+            break
+        time.sleep(args.interval)
+
+    cur.close()
+    conn.close()
+    print(f"\nDone. {placed} placed, {updated} updated, "
+          f"{cancelled} cancelled, {deleted} deleted across {ticks} tick(s).")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Moves the batch pipelines to an hourly cadence, fixes a data-loss bug that hourly would otherwise trigger, and adds a generator for watching records flow end to end.

## 1. Hourly cadence

`ingest_source_to_bronze` and `spark_transform_silver` now run `@hourly` instead of `@daily`. Extraction is incremental against the cursor high-water mark, so a shorter cadence simply means fewer rows per run and fresher warehouse and lakehouse data.

The schedule is read from `INGEST_SCHEDULE` / `SILVER_SCHEDULE` (surfaced through the `etl-env` ConfigMap and the Airflow Helm values) so an environment can choose a different cadence without a code change or image rebuild.

## 2. The bug hourly exposes — data loss in the lakehouse

Bronze objects were keyed `{table}_source/{Y}/{m}/{d}/part-00000.parquet` and uploaded with `replace=True`.

One run a day made that harmless. At hourly, all 24 runs write the **same object** — and because each incremental run holds only its own new rows, every run overwrites the last. The warehouse is unaffected (it upserts to Postgres from the same dataframe), but the lakehouse reads that daily folder and would silently retain roughly **1/24 of each day**. No error, no failed task, just quietly wrong numbers in Trino.

The filename now carries the run timestamp. The daily folder the Spark jobs read is unchanged, every run is preserved, and a retry reuses its own stamp so re-running a task stays idempotent.

```
before:  3 same-day runs -> 1 object   (2 runs lost)
after:   3 same-day runs -> 3 objects  (all rows recovered)
```

## 3. Two more things hourly needs

- **`max_active_runs=1`** on both DAGs. A run that overruns its slot would otherwise overlap the next and race on the raw tables and high-water mark, or MERGE into the same Iceberg tables concurrently.
- **Weekly maintenance gate.** It compared only the date, which is identical for all 24 Sunday runs, so Iceberg compaction would have run **24 times a week**. It now compares weekday *and* hour, pinned to UTC with `date -u` so it cannot drift with the container timezone.

## 4. Live-traffic generator

`scripts/simulate_live_traffic.py` produces a continuous stream of source changes for end-to-end testing. Each tick places new orders with line items, advances statuses, and periodically cancels and deletes — so inserts, updates *and* deletes all reach the CDC stream.

Unlike `generate_ecommerce.py`, it never drops tables, so the replication slot, the mirror and the batch high-water mark stay valid while it runs. Order totals are kept equal to the sum of their lines, so the gold layer's reconciliation stays exact.

```bash
python scripts/simulate_live_traffic.py --rate 5 --interval 3
python scripts/simulate_live_traffic.py --once          # single tick
python scripts/simulate_live_traffic.py --duration 15   # stop after 15 min
```

DEPLOY_GUIDE gains a Step 8 walking through the exercise, with a table of where to look per pipeline and when each one moves.

## Verification

| Check | Result |
|---|---|
| Maintenance gate across a full week of hourly runs | fires **1 of 168**, and still fires under `@daily` |
| Three same-day runs (against live MinIO) | **3 distinct objects**, every row recovered from the daily folder |
| Mirror tracking continuous traffic, no intervention | source 605 → 633, ClickHouse **633** |
| Incremental extract after that traffic | correctly identified the **49 changed rows** for the next run |
| DAG parse, `@hourly` defaults, `max_active_runs` | both DAGs pass |
| `helm template` | renders the new env into all pod specs |
| Full e2e | **9/9** |

ruff / bandit / yamllint / markdownlint clean.

## Note for existing clusters

The ConfigMap already exists, so `deploy.sh` will update it on the next run. To apply the cadence without a full redeploy:

```bash
kubectl patch configmap etl-env -n etl -p '{"data":{"INGEST_SCHEDULE":"@hourly","SILVER_SCHEDULE":"@hourly"}}'
kubectl rollout restart deployment/airflow-scheduler deployment/airflow-dag-processor -n etl
```