### PR TITLE
Target Strimzi 1.x (KRaft, v1 API) and pin the operator version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Validate Kubernetes manifests
         # -ignore-missing-schemas: Strimzi Kafka CRDs have no upstream schema
         # helm-values.yaml is a Helm values file, not a manifest
-        run: kubeconform -ignore-missing-schemas -ignore-filename-pattern 'helm-values.yaml' -summary -skip Kafka k8s/
+        run: kubeconform -ignore-missing-schemas -ignore-filename-pattern 'helm-values.yaml' -summary -skip Kafka,KafkaNodePool k8s/
 
   # ── Application builds & integration ─────────────────────────────────────
 

--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -133,7 +133,7 @@ airflow-dag-processor-xxx           1/1     Running
 alertmanager-xxx                    1/1     Running
 clickhouse-0                        1/1     Running
 data-dashboard-xxx                  1/1     Running
-etl-kafka-broker-0                  1/1     Running
+etl-kafka-dual-role-0               1/1     Running
 grafana-xxx                         1/1     Running
 kafka-connect-0                     1/1     Running
 kafka-exporter-xxx                  1/1     Running

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -13,6 +13,9 @@ set -euo pipefail
 
 NAMESPACE="etl"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# Pinned so an upstream release cannot change the API our manifests target.
+# k8s/kafka/kafka-cluster.yaml is written against this version's v1 API.
+STRIMZI_VERSION="${STRIMZI_VERSION:-1.1.0}"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
 info()  { echo -e "${BLUE}[INFO]${NC}  $*"; }
@@ -154,9 +157,14 @@ fi
 # ─── Step 5: Strimzi Kafka Operator & Kafka Cluster ───────────────────────────
 echo ""
 
-info "Deploying Strimzi Kafka Operator..."
+info "Deploying Strimzi Kafka Operator (${STRIMZI_VERSION})..."
 kubectl create namespace $NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
-kubectl apply -f 'https://strimzi.io/install/latest?namespace=etl' -n $NAMESPACE
+# Pinned, not 'latest': Strimzi 1.x dropped the v1beta2 API and ZooKeeper, so a
+# floating install silently stops matching k8s/kafka/kafka-cluster.yaml. The
+# release asset defaults to namespace "myproject", hence the rewrite.
+curl -fsSL "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${STRIMZI_VERSION}/strimzi-cluster-operator-${STRIMZI_VERSION}.yaml" \
+  | sed "s/namespace: myproject/namespace: ${NAMESPACE}/g" \
+  | kubectl apply -n $NAMESPACE -f -
 kubectl rollout status deployment/strimzi-cluster-operator -n $NAMESPACE --timeout=300s
 # The operator being up does not mean its CRDs are servable yet. Applying the
 # Kafka resource too early fails with: no matches for kind "Kafka" in version

--- a/k8s/kafka/kafka-cluster.yaml
+++ b/k8s/kafka/kafka-cluster.yaml
@@ -1,12 +1,35 @@
-apiVersion: kafka.strimzi.io/v1beta2
+# Kafka for Strimzi 1.x (KRaft only — ZooKeeper was removed upstream).
+#
+# Node count and storage live on the KafkaNodePool; the Kafka resource carries
+# cluster-wide settings. A single dual-role node (controller + broker) matches
+# the single-broker topology this POC uses everywhere else.
+#
+# deploy.sh rewrites the `class:` line below with the StorageClass you choose.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaNodePool
+metadata:
+  name: dual-role
+  namespace: etl
+  labels:
+    strimzi.io/cluster: etl-kafka
+spec:
+  replicas: 1
+  roles:
+    - controller
+    - broker
+  storage:
+    type: persistent-claim
+    size: 10Gi
+    deleteClaim: false
+    class: standard
+---
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: etl-kafka
   namespace: etl
 spec:
   kafka:
-    version: 3.5.0
-    replicas: 1
     listeners:
       - name: plain
         port: 9092
@@ -16,22 +39,13 @@ spec:
         port: 9093
         type: internal
         tls: true
+    # Single-broker POC: every replication factor has to be 1.
     config:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      inter.broker.protocol.version: "3.5"
-    storage:
-      type: persistent-claim
-      size: 10Gi
-      deleteClaim: false
-      class: standard
-  zookeeper:
-    replicas: 1
-    storage:
-      type: persistent-claim
-      size: 2Gi
-      deleteClaim: false
-      class: standard
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}


### PR DESCRIPTION
Fixes the Kafka failure still reported in #94 after the CRD-race fix.

## Root cause

The apply kept failing with:

```
no matches for kind "Kafka" in version "kafka.strimzi.io/v1beta2"
```

even though the CRD wait now passes and reports `condition met`. That ruled out the race.

The real cause: `deploy.sh` installed `https://strimzi.io/install/latest`, and **latest is now Strimzi 1.1.0**. I downloaded it and inspected the CRDs:

```
Kafka CRD versions:
  v1: served=True storage=True          <- v1beta2 is gone entirely
spec properties: [clientsCa, clusterCa, cruiseControl, entityOperator,
                  kafka, kafkaExporter, maintenanceTimeWindows]   <- no 'zookeeper'
```

Our manifest targeted `v1beta2` and carried a `zookeeper` section. It was written for Strimzi 0.x, so the API it asked for genuinely no longer exists on the cluster. Nothing was wrong with the wait.

## Changes

**Kafka cluster rewritten for Strimzi 1.x.** A `KafkaNodePool` now holds `replicas` and `storage` for a single dual-role (controller + broker) node; the `Kafka` resource keeps listeners and cluster config. ZooKeeper is gone — Kubernetes now runs **KRaft**, matching what docker-compose has always done, so the two environments finally agree.

**Operator version pinned.** `STRIMZI_VERSION` defaults to `1.1.0` instead of tracking `latest`. Tracking `latest` is what let an upstream major release silently break the deploy; this is the actual root-cause fix. `strimzi.io/install/<version>` 404s, so the pinned GitHub release asset is used and its default `myproject` namespace rewritten on the way in.

**Follow-ons.** `kubeconform` skip list gains `KafkaNodePool`; DEPLOY_GUIDE's pod list corrected — node pools name pods after the pool, so it is `etl-kafka-dual-role-0`, not `etl-kafka-broker-0`.

## Verification

Without a cluster, the strongest available check is validating the manifests against the **real CRD schemas** shipped by Strimzi 1.1.0:

```
OK   KafkaNodePool/dual-role  (kafka.strimzi.io/v1) validates against the installed CRD
OK   Kafka/etl-kafka          (kafka.strimzi.io/v1) validates against the installed CRD
RESULT: ALL VALID
```

Also confirmed:
- the pinned release asset resolves (HTTP 200, `quay.io/strimzi/operator:1.1.0`)
- deploy.sh's StorageClass rewrite still lands on the node pool's `class:` line
- the bootstrap service keeps the `<cluster>-kafka-bootstrap` name, so kafka-connect, kafka-ui, kafka-exporter and `etl-env` need no change
- shellcheck / yamllint / markdownlint clean

The end-to-end behaviour still needs a real cluster to confirm.