### PR TITLE
Declare airflowVersion and enableServiceLinks in the Airflow chart values

### DIFF
--- a/k8s/airflow/helm-values.yaml
+++ b/k8s/airflow/helm-values.yaml
@@ -3,6 +3,18 @@
 
 executor: KubernetesExecutor
 
+# Match the Airflow actually running: docker/airflow/Dockerfile builds on
+# apache/airflow:3.3.0. Left unset, the chart assumes its own default (3.2.2)
+# and reports that on install, which reads as though the version pin never
+# took effect.
+airflowVersion: "3.3.0"
+
+# We resolve every service by DNS (see the *_HOST entries in etl-env), so the
+# legacy per-service environment variables are dead weight. Setting this
+# explicitly also silences the chart's deprecation warning and keeps behaviour
+# identical when Chart 2.0 flips the default.
+enableServiceLinks: false
+
 config:
   core:
     auth_manager: "airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager"


### PR DESCRIPTION
Closes #97, and fixes a more misleading detail spotted in the same output.

## The deprecation (what #97 reported)

```
DEPRECATION WARNING:
  The default for `enableServiceLinks` will become False in Chart 2.0.
```

Every host in this stack is resolved by DNS — the `*_HOST` entries in `etl-env` are fully-qualified service names. I confirmed nothing under `airflow/`, `k8s/`, `scripts/`, `spark/` or `dbt/` reads a `*_SERVICE_HOST` or `*_PORT_n_TCP` variable, so the legacy per-service env vars are dead weight.

Setting `enableServiceLinks: false` explicitly silences the warning and means the Chart 2.0 upgrade is a no-op for us rather than a behaviour change.

## The more misleading part

The same install printed:

```
Thank you for installing Apache Airflow 3.2.2!
```

…while `docker/airflow/Dockerfile` builds on `apache/airflow:3.3.0-python3.11` and both requirements files pin `apache-airflow==3.3.0`.

`NOTES.txt` renders `.Values.airflowVersion`, which we never set, so the chart fell back to its own default of `3.2.2`. **Nothing was actually running 3.2.2** — we override `images.airflow.repository`/`tag`, so all 13 Airflow containers use our custom image. But since that 3.3.0 pin was taken for CVE fixes, a banner announcing 3.2.2 is exactly the kind of thing that makes someone think the bump never landed. Now declared as `3.3.0`.

## Verification

`helm template` against chart 1.22.0:

- renders clean
- `enableServiceLinks: false` present in all **8** pod specs
- all **13** Airflow containers still resolve to the custom image
- diffing the render with and without `airflowVersion` shows only the randomly-generated fernet/JWT/API secrets changing, i.e. no behavioural change today — this is about accuracy and future chart logic
- yamllint clean