### PR TITLE
Give the Airflow scheduler and API server time to start

### DIFF
--- a/k8s/airflow/helm-values.yaml
+++ b/k8s/airflow/helm-values.yaml
@@ -149,14 +149,25 @@ logs:
 redis:
   enabled: false
 
+# The custom image is large (Spark, JDK, dbt, Cosmos, the AWS providers), so
+# importing it takes roughly two minutes — well past the chart's default
+# startup budget of failureThreshold(6) x periodSeconds(10) = 60s. The probe
+# then kills the container mid-start, forever: CrashLoopBackOff that looks
+# like a crash but is a timeout. dagProcessor has no startup probe, which is
+# why it stays healthy while these two restart.
+# 30 x 10s gives 5 minutes to boot; the probe only applies during startup.
 scheduler:
   resources:
     requests:
-      memory: "512Mi"
-      cpu: "250m"
-    limits:
       memory: "1Gi"
       cpu: "500m"
+    limits:
+      memory: "2Gi"
+      cpu: "2"
+  startupProbe:
+    failureThreshold: 30
+    periodSeconds: 10
+    timeoutSeconds: 20
 
 createUserJob:
   useHelmHooks: true
@@ -173,11 +184,16 @@ createUserJob:
 apiServer:
   resources:
     requests:
-      memory: "512Mi"
-      cpu: "250m"
-    limits:
       memory: "1Gi"
       cpu: "500m"
+    limits:
+      memory: "2Gi"
+      cpu: "2"
+  # See the note on scheduler above — same 60s default, same consequence.
+  startupProbe:
+    failureThreshold: 30
+    periodSeconds: 10
+    timeoutSeconds: 20
   service:
     type: NodePort
     ports:


### PR DESCRIPTION
Diagnoses and fixes the `airflow-api-server` / `airflow-scheduler` CrashLoopBackOff reported during the cluster deploy.

## It is not a crash — it is a timeout

The chart's default startup probe allows `failureThreshold(6) x periodSeconds(10)` = **60 seconds**. Measured against our image:

```
122s  from process start to 'Application startup complete'
```

The probe kills the container mid-start, kubelet restarts it, and it never gets further. The result looks like a crashing application but is a boot that is never allowed to finish. Our image is 5.31 GB and imports Spark, the JDK, dbt, Cosmos and the AWS providers before serving anything.

## The correlation confirms it

| Component | startup probe | His result |
|---|---|---|
| `apiServer` | 60s budget | CrashLoopBackOff, 9 restarts |
| `scheduler` | 60s budget | 1/2 Running, 7 restarts |
| `dagProcessor` | **none** | 3/3 Running, 0 restarts |

The only two components with a startup probe are exactly the two failing, on the same image, in the same cluster. The `cpu: 500m` limit we set made it worse, since the slow part is importing, not serving.

## Fix

- startup budget raised to `30 x 10s` = **300s** (the probe only applies while booting, so headroom costs nothing at runtime)
- limits lifted to **2 CPU / 2Gi**, requests to 500m / 1Gi

Rendered and verified:

```
airflow-api-server/api-server: startup budget=300s  cpu_limit=2  mem_limit=2Gi
airflow-scheduler/scheduler:   startup budget=300s  cpu_limit=2  mem_limit=2Gi
```

## Ruled out, recorded so nobody retries them

Two plausible theories that turned out to be wrong, both tested directly against `apache/airflow:3.3.0-python3.11`:

1. **Missing FAB provider.** The chart config sets `auth_manager` to `FabAuthManager`, and `apache-airflow-providers-fab` is in neither requirements file — but `airflow.providers.fab.auth_manager.fab_auth_manager` **is present in the base image**.
2. **Bad auth config.** Starting the API server with the exact `auth_manager` and `auth_backends` values the chart applies reaches `Application startup complete` cleanly. It also survives a hard `--memory=1g` limit, so memory alone was not the cause either.

`helm template` renders clean; yamllint clean.