### PR TITLE
Read test credentials from the cluster, and fail fast on bad ones

### DIFF
--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -105,23 +105,37 @@ ok "Python environment ready"
 info "Running transactional test suite..."
 echo ""
 
+# Credentials come from the cluster we are testing, not from literals. The
+# checked-in defaults only match a cluster deployed without
+# generate-secrets.sh; hardcoding them made this script fail against exactly
+# the setup we recommend, and the failure looked like a broken pipeline
+# (SignatureDoesNotMatch from MinIO, 403 from ClickHouse) rather than a bad
+# password. Each value falls back to the compose default when the secret or
+# key is absent, so local docker-compose runs still work.
+sv() {  # $1 = key in etl-secrets, $2 = fallback
+  local v
+  v=$(kubectl get secret etl-secrets -n "$NAMESPACE" -o "jsonpath={.data.$1}" 2>/dev/null | base64 -d 2>/dev/null || true)
+  echo "${v:-$2}"
+}
+
 export SOURCE_DB_HOST=localhost
 export SOURCE_DB_PORT=5433
 export DEST_DB_HOST=localhost
 export DEST_DB_PORT=5434
 export KAFKA_CONNECT_URL="http://localhost:8084"
 export MINIO_ENDPOINT="http://localhost:9000"
-export SOURCE_DB_NAME=sourcedb
-export SOURCE_DB_USER=sourceuser
-export SOURCE_DB_PASSWORD=sourcepass
-export DEST_DB_NAME=destdb
-export DEST_DB_USER=destuser
-export DEST_DB_PASSWORD=destpass
-export MINIO_ROOT_USER=minioadmin
-export MINIO_ROOT_PASSWORD=minioadmin123
 export CLICKHOUSE_URL="http://localhost:8123"
-export CLICKHOUSE_USER=chuser
-export CLICKHOUSE_PASSWORD=chpass123
+
+SOURCE_DB_NAME=$(sv SOURCE_DB_NAME sourcedb);            export SOURCE_DB_NAME
+SOURCE_DB_USER=$(sv SOURCE_DB_USER sourceuser);          export SOURCE_DB_USER
+SOURCE_DB_PASSWORD=$(sv SOURCE_DB_PASSWORD sourcepass);  export SOURCE_DB_PASSWORD
+DEST_DB_NAME=$(sv DEST_DB_NAME destdb);                  export DEST_DB_NAME
+DEST_DB_USER=$(sv DEST_DB_USER destuser);                export DEST_DB_USER
+DEST_DB_PASSWORD=$(sv DEST_DB_PASSWORD destpass);        export DEST_DB_PASSWORD
+MINIO_ROOT_USER=$(sv MINIO_ROOT_USER minioadmin);        export MINIO_ROOT_USER
+MINIO_ROOT_PASSWORD=$(sv MINIO_ROOT_PASSWORD minioadmin123); export MINIO_ROOT_PASSWORD
+CLICKHOUSE_USER=$(sv CLICKHOUSE_USER chuser);            export CLICKHOUSE_USER
+CLICKHOUSE_PASSWORD=$(sv CLICKHOUSE_PASSWORD chpass123); export CLICKHOUSE_PASSWORD
 
 set +e   # don't exit on test failure — we want the cleanup trap to run
 python3 "$REPO_ROOT/scripts/test_transactions.py"

--- a/scripts/test_transactions.py
+++ b/scripts/test_transactions.py
@@ -385,6 +385,10 @@ def simulate_transactions():
 
 
 # ── Step 5: Verify the ClickHouse mirror (Pipe 3's real consumer) ─────────────
+class ClickHouseAuthError(RuntimeError):
+    """Wrong ClickHouse credentials — retrying will never help."""
+
+
 def ch_query(sql):
     """Run a read-only query against ClickHouse, return list of rows."""
     r = requests.post(
@@ -393,6 +397,12 @@ def ch_query(sql):
         data=sql,
         timeout=15,
     )
+    if r.status_code in (401, 403):
+        raise ClickHouseAuthError(
+            f"ClickHouse rejected user '{CLICKHOUSE_USER}' (HTTP {r.status_code}). "
+            "Set CLICKHOUSE_USER/CLICKHOUSE_PASSWORD to match the deployment "
+            "(scripts/test_e2e.sh reads them from the etl-secrets secret)."
+        )
     r.raise_for_status()
     return r.json().get("data", [])
 
@@ -420,6 +430,11 @@ def verify_clickhouse(txn, max_order_id):
             ch_count = int(ch_query(f"SELECT count() FROM mirror.orders_current WHERE {scope}")[0][0])  # nosec B608
             if ch_count == src_count:
                 break
+        except ClickHouseAuthError as e:
+            # Credentials will not fix themselves — stop instead of spending
+            # 90 seconds printing the same rejection.
+            fail("ClickHouse authentication failed", str(e))
+            return
         except Exception as e:
             print(f"  waiting for ClickHouse… ({e})")
         time.sleep(5)


### PR DESCRIPTION
Fixes the two failures in the #101 verification run. Both were the test harness, not the pipeline.

## Hardcoded credentials

`scripts/test_e2e.sh` set every credential as a literal:

```bash
export MINIO_ROOT_PASSWORD=minioadmin123
export CLICKHOUSE_PASSWORD=chpass123
```

Those only match a cluster deployed **without** `generate-secrets.sh` — the setup the deploy guide explicitly steers people away from. On a generated-secrets cluster the result was `SignatureDoesNotMatch` from MinIO and `403` from ClickHouse, which reads as a broken pipeline rather than a wrong password.

This is the same defect fixed three times in `deploy.sh` (MinIO buckets, seed job, CDC connector). The test harness was never audited alongside it — my miss. Every value now comes from `etl-secrets`, falling back to the compose default when the secret or key is absent, so local docker-compose runs are unaffected.

## Misleading failure reporting

A 403 is not a readiness problem, but the ClickHouse poll treated **every** exception as "not ready yet":

```
waiting for ClickHouse… (403 Client Error: Forbidden ...)     x18
✗  Row count mismatch  (source=195, clickhouse=-1)
Traceback ... requests.exceptions.HTTPError: 403
```

Ninety seconds spent retrying an error that could never resolve, then a traceback from an unguarded call. Authentication failures now raise a distinct `ClickHouseAuthError`, are not retried, and name the variables to set.

## Verification

- With no cluster reachable the fallback resolves to the compose defaults (`minioadmin123`, `chuser`), so compose runs are unchanged
- Against a live ClickHouse with a deliberately wrong password, the new path fails immediately with the clear message instead of looping 18 times
- ruff / py_compile / shellcheck / bash -n clean
