### PR TITLE
Converge the ClickHouse mirror schema on every deploy

### DIFF
--- a/docker/clickhouse/initdb/01_mirror_schema.sql
+++ b/docker/clickhouse/initdb/01_mirror_schema.sql
@@ -33,14 +33,23 @@ CREATE TABLE IF NOT EXISTS mirror.customers
 ENGINE = ReplacingMergeTree(ver, is_deleted)
 ORDER BY customer_id;
 
-CREATE TABLE IF NOT EXISTS mirror.kafka_customers (raw String)
+-- The consumer and its view carry no data, so they are rebuilt every time this
+-- script runs. With IF NOT EXISTS they were created once and then frozen: a
+-- changed broker address, topic or column mapping never reached a cluster whose
+-- volume already existed. Dropping them re-reads the settings below; the
+-- ReplacingMergeTree above keeps its rows, and the consumer group name is
+-- unchanged so it resumes from its committed offsets.
+DROP VIEW IF EXISTS mirror.customers_mv;
+DROP TABLE IF EXISTS mirror.kafka_customers;
+
+CREATE TABLE mirror.kafka_customers (raw String)
 ENGINE = Kafka
 SETTINGS kafka_broker_list = 'kafka:9092',
          kafka_topic_list = 'cdc.public.customers',
          kafka_group_name = 'clickhouse-mirror-customers',
          kafka_format = 'JSONAsString';
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS mirror.customers_mv TO mirror.customers AS
+CREATE MATERIALIZED VIEW mirror.customers_mv TO mirror.customers AS
 WITH
     JSONExtractString(raw, 'op') AS op,
     if(op = 'd', JSONExtractRaw(raw, 'before'), JSONExtractRaw(raw, 'after')) AS rec
@@ -60,7 +69,7 @@ SELECT
 FROM mirror.kafka_customers
 WHERE length(raw) > 0 AND rec NOT IN ('', 'null');
 
-CREATE VIEW IF NOT EXISTS mirror.customers_current AS
+CREATE OR REPLACE VIEW mirror.customers_current AS
 SELECT * EXCEPT (ver, is_deleted) FROM mirror.customers FINAL WHERE is_deleted = 0;
 
 -- ── products ─────────────────────────────────────────────────────────────
@@ -80,14 +89,23 @@ CREATE TABLE IF NOT EXISTS mirror.products
 ENGINE = ReplacingMergeTree(ver, is_deleted)
 ORDER BY product_id;
 
-CREATE TABLE IF NOT EXISTS mirror.kafka_products (raw String)
+-- The consumer and its view carry no data, so they are rebuilt every time this
+-- script runs. With IF NOT EXISTS they were created once and then frozen: a
+-- changed broker address, topic or column mapping never reached a cluster whose
+-- volume already existed. Dropping them re-reads the settings below; the
+-- ReplacingMergeTree above keeps its rows, and the consumer group name is
+-- unchanged so it resumes from its committed offsets.
+DROP VIEW IF EXISTS mirror.products_mv;
+DROP TABLE IF EXISTS mirror.kafka_products;
+
+CREATE TABLE mirror.kafka_products (raw String)
 ENGINE = Kafka
 SETTINGS kafka_broker_list = 'kafka:9092',
          kafka_topic_list = 'cdc.public.products',
          kafka_group_name = 'clickhouse-mirror-products',
          kafka_format = 'JSONAsString';
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS mirror.products_mv TO mirror.products AS
+CREATE MATERIALIZED VIEW mirror.products_mv TO mirror.products AS
 WITH
     JSONExtractString(raw, 'op') AS op,
     if(op = 'd', JSONExtractRaw(raw, 'before'), JSONExtractRaw(raw, 'after')) AS rec
@@ -105,7 +123,7 @@ SELECT
 FROM mirror.kafka_products
 WHERE length(raw) > 0 AND rec NOT IN ('', 'null');
 
-CREATE VIEW IF NOT EXISTS mirror.products_current AS
+CREATE OR REPLACE VIEW mirror.products_current AS
 SELECT * EXCEPT (ver, is_deleted) FROM mirror.products FINAL WHERE is_deleted = 0;
 
 -- ── orders ─────────────────────────────────────────────────────────────
@@ -124,14 +142,23 @@ CREATE TABLE IF NOT EXISTS mirror.orders
 ENGINE = ReplacingMergeTree(ver, is_deleted)
 ORDER BY order_id;
 
-CREATE TABLE IF NOT EXISTS mirror.kafka_orders (raw String)
+-- The consumer and its view carry no data, so they are rebuilt every time this
+-- script runs. With IF NOT EXISTS they were created once and then frozen: a
+-- changed broker address, topic or column mapping never reached a cluster whose
+-- volume already existed. Dropping them re-reads the settings below; the
+-- ReplacingMergeTree above keeps its rows, and the consumer group name is
+-- unchanged so it resumes from its committed offsets.
+DROP VIEW IF EXISTS mirror.orders_mv;
+DROP TABLE IF EXISTS mirror.kafka_orders;
+
+CREATE TABLE mirror.kafka_orders (raw String)
 ENGINE = Kafka
 SETTINGS kafka_broker_list = 'kafka:9092',
          kafka_topic_list = 'cdc.public.orders',
          kafka_group_name = 'clickhouse-mirror-orders',
          kafka_format = 'JSONAsString';
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS mirror.orders_mv TO mirror.orders AS
+CREATE MATERIALIZED VIEW mirror.orders_mv TO mirror.orders AS
 WITH
     JSONExtractString(raw, 'op') AS op,
     if(op = 'd', JSONExtractRaw(raw, 'before'), JSONExtractRaw(raw, 'after')) AS rec
@@ -148,7 +175,7 @@ SELECT
 FROM mirror.kafka_orders
 WHERE length(raw) > 0 AND rec NOT IN ('', 'null');
 
-CREATE VIEW IF NOT EXISTS mirror.orders_current AS
+CREATE OR REPLACE VIEW mirror.orders_current AS
 SELECT * EXCEPT (ver, is_deleted) FROM mirror.orders FINAL WHERE is_deleted = 0;
 
 -- ── order_items ─────────────────────────────────────────────────────────────
@@ -167,14 +194,23 @@ CREATE TABLE IF NOT EXISTS mirror.order_items
 ENGINE = ReplacingMergeTree(ver, is_deleted)
 ORDER BY item_id;
 
-CREATE TABLE IF NOT EXISTS mirror.kafka_order_items (raw String)
+-- The consumer and its view carry no data, so they are rebuilt every time this
+-- script runs. With IF NOT EXISTS they were created once and then frozen: a
+-- changed broker address, topic or column mapping never reached a cluster whose
+-- volume already existed. Dropping them re-reads the settings below; the
+-- ReplacingMergeTree above keeps its rows, and the consumer group name is
+-- unchanged so it resumes from its committed offsets.
+DROP VIEW IF EXISTS mirror.order_items_mv;
+DROP TABLE IF EXISTS mirror.kafka_order_items;
+
+CREATE TABLE mirror.kafka_order_items (raw String)
 ENGINE = Kafka
 SETTINGS kafka_broker_list = 'kafka:9092',
          kafka_topic_list = 'cdc.public.order_items',
          kafka_group_name = 'clickhouse-mirror-order-items',
          kafka_format = 'JSONAsString';
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS mirror.order_items_mv TO mirror.order_items AS
+CREATE MATERIALIZED VIEW mirror.order_items_mv TO mirror.order_items AS
 WITH
     JSONExtractString(raw, 'op') AS op,
     if(op = 'd', JSONExtractRaw(raw, 'before'), JSONExtractRaw(raw, 'after')) AS rec
@@ -191,5 +227,5 @@ SELECT
 FROM mirror.kafka_order_items
 WHERE length(raw) > 0 AND rec NOT IN ('', 'null');
 
-CREATE VIEW IF NOT EXISTS mirror.order_items_current AS
+CREATE OR REPLACE VIEW mirror.order_items_current AS
 SELECT * EXCEPT (ver, is_deleted) FROM mirror.order_items FINAL WHERE is_deleted = 0;

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -210,6 +210,23 @@ kubectl create configmap clickhouse-init -n $NAMESPACE \
   --from-file="$CH_INIT_DIR" --dry-run=client -o yaml | kubectl apply -f -
 kubectl apply -f "$TMP_K8S/clickhouse/"
 kubectl rollout status statefulset/clickhouse -n $NAMESPACE --timeout=300s
+
+# The ConfigMap is mounted at /docker-entrypoint-initdb.d, which ClickHouse only
+# executes on first boot of an empty volume. Applying it explicitly means schema
+# changes — a new table, a different broker address, an altered column mapping —
+# also reach clusters whose volume already exists. The script is safe to re-run:
+# data tables use IF NOT EXISTS, and only the stateless Kafka consumers and their
+# views are rebuilt.
+info "Applying the mirror schema (idempotent, so existing volumes converge)..."
+if kubectl exec -i clickhouse-0 -n $NAMESPACE -- clickhouse-client \
+     --user "$(secret_val CLICKHOUSE_USER)" \
+     --password "$(secret_val CLICKHOUSE_PASSWORD)" \
+     --multiquery < "$CH_INIT_DIR/01_mirror_schema.sql"; then
+  ok "Mirror schema applied"
+else
+  warn "Could not apply the mirror schema — the real-time mirror may not receive changes"
+  warn "Retry with: kubectl exec -i clickhouse-0 -n $NAMESPACE -- clickhouse-client --user <u> --password <p> --multiquery < docker/clickhouse/initdb/01_mirror_schema.sql"
+fi
 ok "ClickHouse is ready"
 
 info "Registering Debezium CDC connector (via in-cluster exec)..."

--- a/scripts/generate_pipeline_assets.py
+++ b/scripts/generate_pipeline_assets.py
@@ -60,14 +60,23 @@ CREATE TABLE IF NOT EXISTS mirror.{name}
 ENGINE = ReplacingMergeTree(ver, is_deleted)
 ORDER BY {table['primary_key']};
 
-CREATE TABLE IF NOT EXISTS mirror.kafka_{name} (raw String)
+-- The consumer and its view carry no data, so they are rebuilt every time this
+-- script runs. With IF NOT EXISTS they were created once and then frozen: a
+-- changed broker address, topic or column mapping never reached a cluster whose
+-- volume already existed. Dropping them re-reads the settings below; the
+-- ReplacingMergeTree above keeps its rows, and the consumer group name is
+-- unchanged so it resumes from its committed offsets.
+DROP VIEW IF EXISTS mirror.{name}_mv;
+DROP TABLE IF EXISTS mirror.kafka_{name};
+
+CREATE TABLE mirror.kafka_{name} (raw String)
 ENGINE = Kafka
 SETTINGS kafka_broker_list = 'kafka:9092',
          kafka_topic_list = '{topic}',
          kafka_group_name = '{group}',
          kafka_format = 'JSONAsString';
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS mirror.{name}_mv TO mirror.{name} AS
+CREATE MATERIALIZED VIEW mirror.{name}_mv TO mirror.{name} AS
 WITH
     JSONExtractString(raw, 'op') AS op,
     if(op = 'd', JSONExtractRaw(raw, 'before'), JSONExtractRaw(raw, 'after')) AS rec
@@ -78,7 +87,7 @@ SELECT
 FROM mirror.kafka_{name}
 WHERE length(raw) > 0 AND rec NOT IN ('', 'null');
 
-CREATE VIEW IF NOT EXISTS mirror.{name}_current AS
+CREATE OR REPLACE VIEW mirror.{name}_current AS
 SELECT * EXCEPT (ver, is_deleted) FROM mirror.{name} FINAL WHERE is_deleted = 0;
 ''')  # nosec B608 - code generator emitting SQL from the manifest, not runtime queries
     return '\n'.join(out)


### PR DESCRIPTION
Likely cause of the empty mirror in #101, and a design flaw worth fixing regardless.

## The flaw

The mirror schema is mounted at `/docker-entrypoint-initdb.d`, which ClickHouse runs **only on first boot of an empty volume**, and every object used `IF NOT EXISTS`. Together those mean the schema is written once and then frozen. On a cluster whose volume already exists, a redeploy updates the ConfigMap and changes nothing inside the database — no new table, no changed topic, no changed column mapping.

That has already bitten us. `deploy.sh` rewrites the broker from `kafka:9092` to the Strimzi bootstrap address when it builds the ConfigMap. A ClickHouse volume created before that rename keeps pointing at a service that no longer exists — and **the failure is completely silent**: Debezium reports RUNNING, Kafka holds the messages, and the mirror just stays empty. Exactly the symptom reported in #101.

## The fix

The Kafka engine tables and their materialized views hold no data — they are consumers. They are now dropped and recreated on each run, which re-reads their settings. The `ReplacingMergeTree` tables keep `IF NOT EXISTS` and their rows, and the consumer group name is unchanged so consumption resumes from committed offsets.

`deploy.sh` also applies the schema explicitly once ClickHouse is ready, instead of depending on the volume being fresh.

## Verification — reproduced the failure, then fixed it

Against a live ClickHouse holding 634 rows:

```
1. seeded data                       rows before: 634
2. pointed kafka_orders at a bogus broker
   broker now:   stale-broker:9092
3. re-applied the generated schema
4. broker after: kafka:9092          <- corrected
   rows after:   634                 <- data preserved
   mv exists:    1                   <- consumer rebuilt
```

Then the full e2e to confirm rebuilding the consumer does not interrupt CDC:

```
Total: 9 passed, 0 failed
```

Static checks: manifest `--check` in sync, shellcheck, bash -n, ruff all clean.

## For the cluster in #101

`git pull && bash k8s/deploy.sh` now repairs the schema in place — no volume wipe, no manual SQL, existing mirror rows kept.