### PR TITLE
Stop reporting a pass when the ClickHouse mirror is empty

### DIFF
--- a/scripts/test_transactions.py
+++ b/scripts/test_transactions.py
@@ -444,6 +444,18 @@ def verify_clickhouse(txn, max_order_id):
     else:
         fail("Row count mismatch", f"source={src_count}, clickhouse={ch_count}")
 
+    if ch_count <= 0:
+        # Every check below looks for the *absence* of specific rows, which an
+        # empty mirror satisfies trivially. Reporting those as passes hides the
+        # only fact that matters: no CDC events arrived at all.
+        fail(
+            "Mirror is empty — downstream checks skipped",
+            "no CDC events reached ClickHouse, so delete and cancellation "
+            "verification would pass vacuously. Check the Debezium connector "
+            "task state and the ClickHouse Kafka consumer.",
+        )
+        return
+
     del_ids = ",".join(str(i) for i in txn["deleted"])
     found = int(ch_query(f"SELECT count() FROM mirror.orders_current WHERE order_id IN ({del_ids})")[0][0])  # nosec B608
     if found == 0:


### PR DESCRIPTION
Spotted in the #104 output.

The delete check asserts that specific order ids are **absent** from `mirror.orders_current`. An empty mirror satisfies that trivially, so a run where no CDC event arrived at all still printed:

```
✗  Row count mismatch  (source=195, clickhouse=0)
✓  All 5 deleted orders are gone from the mirror     <- meaningless
✗  Cancellation mismatch (expected 10, got 0)
```

Nothing was deleted, because nothing was ever there. The tick inflates the summary (7 passed / 2 failed reads far better than it should) and implies part of the CDC path is working when none of it is.

When the mirror has no rows in scope, the downstream checks are now skipped with an explicit failure that names what to investigate — the Debezium task state and the ClickHouse Kafka consumer — rather than being evaluated against an empty table.

Verified by forcing the empty-mirror path against a live ClickHouse:

```
✗  Row count mismatch  (source=195, clickhouse=0)
✗  Mirror is empty — downstream checks skipped  (no CDC events reached ClickHouse...)
```

ruff / py_compile clean. This does not fix the empty mirror itself — that is still under investigation in #104 — it stops the test from partially masking it.