### PR TITLE
Deploy smoke test on kind, and enable Kafka topic auto-creation

### DIFF
--- a/.github/workflows/deploy-smoke.yml
+++ b/.github/workflows/deploy-smoke.yml
@@ -1,0 +1,125 @@
+name: Deploy Smoke Test
+
+# Stands the real-time path up on a throwaway kind cluster using the actual
+# deploy script, with generated secrets.
+#
+# Every defect found during the first cluster deployments lived in this path and
+# was invisible to the rest of CI, which validates manifests but never applies
+# them: hardcoded MinIO and CDC credentials that only worked with the checked-in
+# defaults, a Strimzi major release that dropped the API our manifest used, and
+# a mirror schema that never reached an existing volume. Rendering YAML cannot
+# catch any of those; running the deploy can.
+#
+# Airflow, Spark and Trino are deliberately out of scope — the Airflow image
+# alone is several gigabytes. DEPLOY_PROFILE=core stops after ClickHouse.
+
+on:
+  pull_request:
+    paths:
+      - 'k8s/**'
+      - 'scripts/register_debezium_connector.sh'
+      - 'scripts/generate_pipeline_assets.py'
+      - 'docker/clickhouse/**'
+      - '.github/workflows/deploy-smoke.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy-core:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: etl-smoke
+          wait: 120s
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Generate secrets
+        # The whole point: exercise the path the deploy guide recommends.
+        # Random credentials are what exposed the hardcoded ones.
+        run: bash k8s/generate-secrets.sh
+
+      - name: Deploy the real-time path
+        env:
+          REGISTRY: ''            # skip image builds; core profile needs none
+          STORAGE_CLASS: standard # kind's default provisioner
+          SEED: 'n'
+          DEPLOY_PROFILE: core
+        run: bash k8s/deploy.sh
+
+      - name: Assert the deployment is actually healthy
+        run: |
+          set -euo pipefail
+          sv() { kubectl get secret etl-secrets -n etl -o "jsonpath={.data.$1}" | base64 -d; }
+          fail() { echo "::error::$1"; exit 1; }
+
+          echo "--- pods ---"
+          kubectl get pods -n etl
+
+          for sts in postgres-source postgres-dest minio kafka-connect clickhouse; do
+            kubectl rollout status "statefulset/$sts" -n etl --timeout=60s \
+              || fail "$sts is not ready"
+          done
+
+          # Strimzi API compatibility: a major release that drops the version our
+          # manifest targets shows up here as a Kafka that never goes Ready.
+          kubectl wait kafka/etl-kafka --for=condition=Ready --timeout=120s -n etl \
+            || fail "Kafka cluster did not become Ready"
+
+          # MinIO buckets — fails if bucket creation used the wrong credentials.
+          buckets=$(kubectl exec -n etl minio-0 -- sh -c \
+            'mc alias set local http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null && mc ls local' 2>/dev/null)
+          echo "$buckets" | grep -q bronze || fail "bronze bucket missing"
+          echo "$buckets" | grep -q silver || fail "silver bucket missing"
+
+          # The CDC connector must be registered with the *generated* password.
+          # Registering with the checked-in default is the bug that silently
+          # disabled the real-time pipeline.
+          cfg=$(kubectl exec -n etl kafka-connect-0 -- \
+            curl -s localhost:8083/connectors/orders-cdc-connector/config)
+          echo "$cfg" | grep -q "$(sv SOURCE_DB_PASSWORD)" \
+            || fail "connector was not registered with the generated password"
+          echo "$cfg" | grep -q 'sourcepass' \
+            && fail "connector is using the default password, not the deployed one"
+
+          status=$(kubectl exec -n etl kafka-connect-0 -- \
+            curl -s localhost:8083/connectors/orders-cdc-connector/status)
+          echo "$status" | python3 -c "
+          import json,sys
+          d=json.load(sys.stdin)
+          states=[d['connector']['state']]+[t['state'] for t in d.get('tasks',[])]
+          print('connector+task states:', states)
+          sys.exit(0 if all(s=='RUNNING' for s in states) and len(states)>1 else 1)
+          " || fail "connector or its task is not RUNNING"
+
+          # Mirror schema must exist for every table in the manifest.
+          for t in customers products orders order_items; do
+            n=$(kubectl exec -n etl clickhouse-0 -- clickhouse-client \
+                  --user "$(sv CLICKHOUSE_USER)" --password "$(sv CLICKHOUSE_PASSWORD)" \
+                  -q "SELECT count() FROM system.tables WHERE database='mirror' AND name='${t}_current'")
+            [ "$n" = "1" ] || fail "mirror.${t}_current is missing"
+          done
+
+          # And they must point at the in-cluster broker, not the compose name.
+          broker=$(kubectl exec -n etl clickhouse-0 -- clickhouse-client \
+                     --user "$(sv CLICKHOUSE_USER)" --password "$(sv CLICKHOUSE_PASSWORD)" \
+                     -q "SELECT extract(engine_full, 'kafka_broker_list = ''([^'']*)''') FROM system.tables WHERE database='mirror' AND name='kafka_orders'")
+          echo "mirror broker: $broker"
+          case "$broker" in
+            etl-kafka-kafka-bootstrap*) ;;
+            *) fail "mirror is pointed at '$broker', not the in-cluster Kafka bootstrap" ;;
+          esac
+
+          echo "All deploy smoke assertions passed."
+
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get pods -n etl -o wide || true
+          kubectl get events -n etl --sort-by=.lastTimestamp | tail -40 || true
+          kubectl logs -n etl kafka-connect-0 --tail=60 2>/dev/null | grep -v kube-probe || true

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -42,7 +42,13 @@ echo ""
 warn "You need a container registry to push the Airflow image."
 warn "Options: DockerHub (docker.io/USERNAME), GCR (gcr.io/PROJECT), ECR, etc."
 warn "IMPORTANT: Ensure you have run 'docker login' for your registry first."
-read -rp "Enter your registry (e.g. docker.io/myuser): " REGISTRY
+# Presetting REGISTRY (even to empty, meaning "skip the build") suppresses the
+# prompt, so the script can run unattended in CI or any automation.
+if [ -z "${REGISTRY+x}" ]; then
+  read -rp "Enter your registry (e.g. docker.io/myuser): " REGISTRY
+else
+  info "Using REGISTRY from the environment: ${REGISTRY:-(none — skipping image build)}"
+fi
 
 if [ -z "$REGISTRY" ]; then
   warn "Skipping image build — using default apache/airflow:3.3.0-python3.11"
@@ -83,7 +89,9 @@ else
   ok "Found default StorageClass: $DEFAULT_SC"
 fi
 
-read -rp "Enter StorageClass to use [$DEFAULT_SC]: " STORAGE_CLASS
+if [ -z "${STORAGE_CLASS+x}" ]; then
+  read -rp "Enter StorageClass to use [$DEFAULT_SC]: " STORAGE_CLASS
+fi
 STORAGE_CLASS=${STORAGE_CLASS:-$DEFAULT_SC}
 info "Using StorageClass: $STORAGE_CLASS"
 
@@ -249,6 +257,17 @@ else
   warn "Retry with: bash scripts/register_debezium_connector.sh (see DEPLOY_GUIDE)"
 fi
 
+# Everything above is the real-time path: databases, object storage, Kafka,
+# Debezium and the ClickHouse mirror. DEPLOY_PROFILE=core stops here, which is
+# what CI exercises — it covers the parts that have actually broken on fresh
+# installs without pulling the multi-gigabyte Airflow image.
+if [ "${DEPLOY_PROFILE:-full}" = "core" ]; then
+  echo ""
+  ok "Core profile complete (databases, MinIO, Kafka, Debezium, ClickHouse)"
+  info "Set DEPLOY_PROFILE=full for Spark, Trino, monitoring, Airflow and the dashboard."
+  exit 0
+fi
+
 # ─── Step 7: Spark ────────────────────────────────────────────────────────────
 echo ""
 info "Deploying Spark master and workers..."
@@ -309,8 +328,10 @@ ok "Airflow is ready"
 
 # ─── Step 10: Seed sample data ────────────────────────────────────────────────
 echo ""
-read -rp "Seed sample orders data into postgres-source? (y/N): " SEED
-if [[ "$SEED" =~ ^[Yy]$ ]]; then
+if [ -z "${SEED+x}" ]; then
+  read -rp "Seed sample orders data into postgres-source? (y/N): " SEED
+fi
+if [[ "${SEED:-n}" =~ ^[Yy]$ ]]; then
   info "Running data generator (this may take a minute)..."
   SEED_DB_USER=$(secret_val SOURCE_DB_USER)
   SEED_DB_PASSWORD=$(secret_val SOURCE_DB_PASSWORD)

--- a/k8s/kafka/kafka-cluster.yaml
+++ b/k8s/kafka/kafka-cluster.yaml
@@ -46,6 +46,12 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
+      # Debezium creates one topic per captured table on first change event.
+      # Strimzi defaults this to false, unlike docker-compose which sets
+      # KAFKA_AUTO_CREATE_TOPICS_ENABLE=true — so on Kubernetes the producer
+      # looped on UNKNOWN_TOPIC_OR_PARTITION while the connector still
+      # reported RUNNING, and the mirror silently stayed empty.
+      auto.create.topics.enable: "true"
   entityOperator:
     topicOperator: {}
     userOperator: {}


### PR DESCRIPTION
Closes the gap that let seven defects reach a real cluster: CI validates manifests but never applies them.

## The gap

Every problem the first cluster deployments turned up lived in the deploy path — hardcoded MinIO and CDC credentials that only matched the checked-in defaults, a Strimzi major release that dropped the API our manifest targeted, a mirror schema that never reached an existing volume. Rendering YAML catches none of them. Running the deploy does.

## What the job does

Creates a kind cluster, runs `generate-secrets.sh` (the path the guide recommends, and the one that exposed the hardcoded credentials), then runs **the real `deploy.sh`** and asserts:

- every core workload Ready
- the Kafka custom resource accepted and Ready → catches a Strimzi API break
- both MinIO buckets present → catches bucket-credential drift
- the CDC connector registered with the **generated** password, explicitly not `sourcepass`, task RUNNING → catches the silent connector bug
- the mirror schema present for every manifest table, its Kafka tables pointed at the in-cluster broker → catches schema drift

So CI drives the same script users run rather than a parallel copy that can drift, `deploy.sh` now reads `REGISTRY`, `STORAGE_CLASS` and `SEED` from the environment when set, and `DEPLOY_PROFILE=core` stops after ClickHouse — keeping the multi-gigabyte Airflow image out of CI while still covering the path that actually breaks.

## It found a real defect on its first local run

`docker-compose` sets `KAFKA_AUTO_CREATE_TOPICS_ENABLE=true`. The Strimzi cluster set nothing, and **Strimzi defaults it to false**. Debezium could not create its topics:

```
Error while fetching metadata: {cdc.public.orders=UNKNOWN_TOPIC_OR_PARTITION}
```

…while the connector still reported `RUNNING` and the mirror stayed empty — the exact symptom reported in #104. The Kafka config now enables auto-creation, matching compose.

## Honest limitation

I verified this on a local kind cluster: the deploy completes, all assertions above pass, and the `UNKNOWN_TOPIC_OR_PARTITION` errors are direct evidence for the auto-creation defect. **What I could not get working end to end on kind is data actually landing in ClickHouse**, even after enabling auto-creation — the connector sits RUNNING and idle. So this fix is necessary but I cannot yet claim it is sufficient for #104.

That is also why the job asserts structure rather than data flow: a green tick should mean something. Adding a real insert-to-mirror assertion is the obvious next step once the remaining piece is understood.