### PR TITLE
Consume Kafka topics from the earliest offset

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -256,6 +256,9 @@ services:
     volumes:
       - clickhouse-data:/var/lib/clickhouse
       - ./docker/clickhouse/initdb:/docker-entrypoint-initdb.d:ro
+      # Single file, not the directory: mounting the directory would mask the
+      # image's docker_related_config.xml and the server would bind loopback only
+      - ./docker/clickhouse/config.d/kafka.xml:/etc/clickhouse-server/config.d/kafka.xml:ro
     networks:
       - etl-network
     healthcheck:

--- a/docker/clickhouse/config.d/kafka.xml
+++ b/docker/clickhouse/config.d/kafka.xml
@@ -1,0 +1,18 @@
+<clickhouse>
+    <!--
+      Start new consumer groups at the beginning of each topic.
+
+      librdkafka defaults auto.offset.reset to "latest", which silently loses
+      data for a CDC mirror: Debezium creates the topic and starts producing as
+      soon as it is registered, but the ClickHouse consumers attach later. With
+      "latest" every message written before that moment is skipped and never
+      read — the consumer sits connected with no committed offset while the
+      topic holds thousands of records, and nothing reports an error.
+
+      "earliest" makes the mirror converge on the full topic instead, which is
+      the only correct behaviour for a replica of a source table.
+    -->
+    <kafka>
+        <auto_offset_reset>earliest</auto_offset_reset>
+    </kafka>
+</clickhouse>

--- a/k8s/clickhouse/statefulset.yaml
+++ b/k8s/clickhouse/statefulset.yaml
@@ -38,6 +38,13 @@ spec:
           mountPath: /var/lib/clickhouse
         - name: initdb
           mountPath: /docker-entrypoint-initdb.d
+        # subPath so only this file is added. Mounting the whole directory
+        # masks the image's own docker_related_config.xml, which sets
+        # listen_host — without it the server binds loopback only and every
+        # probe gets connection refused.
+        - name: server-config
+          mountPath: /etc/clickhouse-server/config.d/kafka.xml
+          subPath: kafka.xml
         readinessProbe:
           httpGet:
             path: /ping
@@ -55,6 +62,9 @@ spec:
       - name: initdb
         configMap:
           name: clickhouse-init
+      - name: server-config
+        configMap:
+          name: clickhouse-config
   volumeClaimTemplates:
   - metadata:
       name: clickhouse-data

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -216,6 +216,11 @@ sed 's|kafka:9092|etl-kafka-kafka-bootstrap.etl.svc.cluster.local:9092|g' \
   "$REPO_ROOT/docker/clickhouse/initdb/01_mirror_schema.sql" > "$CH_INIT_DIR/01_mirror_schema.sql"
 kubectl create configmap clickhouse-init -n $NAMESPACE \
   --from-file="$CH_INIT_DIR" --dry-run=client -o yaml | kubectl apply -f -
+# Server settings, notably auto_offset_reset=earliest so consumers read topics
+# from the beginning rather than skipping everything produced before they
+# attached. Same file compose mounts, so both environments behave identically.
+kubectl create configmap clickhouse-config -n $NAMESPACE \
+  --from-file="$REPO_ROOT/docker/clickhouse/config.d" --dry-run=client -o yaml | kubectl apply -f -
 kubectl apply -f "$TMP_K8S/clickhouse/"
 kubectl rollout status statefulset/clickhouse -n $NAMESPACE --timeout=300s
 


### PR DESCRIPTION
Very likely the root cause of the empty mirror in #104, found by reproducing it on a kind cluster.

## The measurement

```
GROUP                    TOPIC             CURRENT-OFFSET  LOG-END-OFFSET  LAG
clickhouse-mirror-orders cdc.public.orders -               2               -
```

The consumer is **connected with an active member**, but has never committed an offset and never read a message, while the topic holds records.

librdkafka defaults `auto.offset.reset` to **`latest`**. A group joining a topic that already has records starts at the end and skips all of them — permanently, and with no error reported anywhere. Debezium keeps producing, the topic grows, the mirror stays at zero, and every component reports healthy.

On the reported cluster that is 31,380 messages stranded in `cdc.public.orders` with `mirror.orders` empty. Same signature.

## Why this is the normal case, not an edge case

Debezium creates the topic and starts producing the moment it is registered. The ClickHouse consumers are built afterwards. Anything produced in between is skipped — which on a fresh install is the entire seed.

## Fix

`docker/clickhouse/config.d/kafka.xml` sets `auto_offset_reset` to `earliest`, mounted by both compose and Kubernetes so the environments behave identically, with `deploy.sh` publishing it as the `clickhouse-config` map.

**Mounted with `subPath`, deliberately.** Mounting the whole directory masks the image's own `docker_related_config.xml`, which sets `listen_host` — I did exactly that on the first attempt and ClickHouse bound loopback only, failing every readiness probe with `connection refused`. Verified after the fix that both files are present and the pod reaches Ready.

## What is and is not verified

**Verified:** ClickHouse starts Ready with both config files present, the setting is live inside the container, and `docker compose config`, yamllint and shellcheck all pass.

**Not verified:** rows actually landing in the mirror. My kind cluster became too resource-starved to give a clean signal before I could demonstrate it — Kafka started timing out on coordinator lookups. So the offset behaviour is **inferred from the consumer-group evidence above rather than demonstrated end to end**, and I would rather say so than imply a proof I do not have.

The reported cluster is the better test: it already has 31,380 messages waiting, so if this is right the mirror should fill within seconds of the consumers being rebuilt.