### PR TITLE
Upgrade ClickHouse to 25.3 so the mirror can consume from Kafka 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ order by revenue desc;
 | **Batch Compute** | Apache Spark 3.5 & Apache Iceberg 1.4 |
 | **Lakehouse Query Engine** | Trino |
 | **Row Warehouse / Mirror** | PostgreSQL 15 |
-| **Columnar Mirror** | ClickHouse 24.8 |
+| **Columnar Mirror** | ClickHouse 25.3 |
 | **AI Assistant** | Next.js + Claude (agentic SQL over all stores) |
 | **BI / Dashboards** | Metabase |
 | **Monitoring** | Prometheus & Grafana |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,7 +238,7 @@ services:
 
   # ClickHouse - columnar hot mirror fed from the CDC topics
   clickhouse:
-    image: clickhouse/clickhouse-server:24.8
+    image: clickhouse/clickhouse-server:25.3
     container_name: clickhouse
     depends_on:
       kafka:

--- a/k8s/clickhouse/statefulset.yaml
+++ b/k8s/clickhouse/statefulset.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: clickhouse
-        image: clickhouse/clickhouse-server:24.8
+        image: clickhouse/clickhouse-server:25.3
         ports:
         - containerPort: 8123   # HTTP
         - containerPort: 9000   # native


### PR DESCRIPTION
Root cause of #104, found in `system.kafka_consumers` on the reported cluster and confirmed by controlled experiment.

## The error

```
last_error:        Local: Required feature not supported by broker
num_messages_read: 32128
is_currently_used: 1
```

A **librdkafka protocol incompatibility**, not configuration. The consumer joins the group and is assigned the partition — which is exactly why `kafka-consumer-groups.sh` showed a healthy-looking member — but every fetch fails. It never reads, never commits, and `CURRENT-OFFSET` stays at `-` forever with no error surfaced anywhere except this one system table.

## I caused this

Migrating to Strimzi 1.x (#96) dropped the pinned `spec.kafka.version`. Strimzi 1.1.0 ships only:

```
kafka-4.2.0   kafka-4.2.1   kafka-4.3.0
```

ClickHouse 24.8's bundled librdkafka cannot negotiate the consumer protocol with a Kafka 4.x broker.

docker-compose kept working the whole time because it runs `cp-kafka:7.5.0` — **Kafka 3.5**. So the environments silently diverged at that migration, and every symptom reported since traces back to it. Pinning Kafka back is not an option: Strimzi 1.1.0 does not support 3.x at all.

## Confirmed by experiment, not inference

Against a real Kafka 4.0 broker with two messages on the topic:

| ClickHouse | Result |
|---|---|
| **24.8** | **0 rows**, `Required feature not supported by broker` — the reported error, reproduced exactly |
| **25.3** | **2 rows consumed**, no error, values correct |

## Regression check

Full end-to-end on compose against a **fresh ClickHouse 25.3 volume**: **9/9 passed**. The upgrade does not disturb the working environment.

## Why the previous four fixes did not help

The hardcoded credentials, schema convergence, consumer ordering and offset reset were all genuine defects and are worth keeping — but none of them could move this symptom. I should have asked for `system.kafka_consumers` several rounds earlier rather than reasoning from the outside; that one query named the cause immediately.