### PR TITLE
Disable Connect schema envelopes so the mirror can parse records

### DIFF
--- a/k8s/kafka-connect/deployment.yaml
+++ b/k8s/kafka-connect/deployment.yaml
@@ -52,6 +52,17 @@ spec:
           value: "org.apache.kafka.connect.json.JsonConverter"
         - name: VALUE_CONVERTER
           value: "org.apache.kafka.connect.json.JsonConverter"
+        # JsonConverter defaults schemas.enable to true, which wraps every
+        # record as {"schema":{...},"payload":{...}}. The ClickHouse
+        # materialized views read op/before/after at the top level, so a
+        # wrapped record yields an empty `rec` and is dropped by the view's
+        # WHERE clause — the consumers report tens of thousands of messages
+        # read while the mirror stays at zero, with no error anywhere.
+        # docker-compose has always set these; Kubernetes did not.
+        - name: CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE
+          value: "false"
+        - name: CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE
+          value: "false"
         - name: HEAP_OPTS
           value: "-Xmx1G -Xms512M"
         resources:


### PR DESCRIPTION
Next layer of #104, and the same environment-parity class as the rest.

## Where we are

After the ClickHouse 25.3 upgrade the consumers are healthy — but nothing lands:

```
kafka_orders        num_messages_read: 33680    last_error: (empty)
kafka_order_items   num_messages_read: 43636    last_error: (empty)
mirror.orders raw:  0
```

Messages are being read. They are just not being parsed.

## Cause

`JsonConverter` defaults `schemas.enable` to **true**, wrapping every record as:

```json
{"schema": {...}, "payload": {"before": null, "after": {...}, "op": "c"}}
```

The materialized views read `op`, `before` and `after` at the **top level**. Against a wrapped record `JSONExtractString(raw,'op')` returns empty, `rec` becomes `''`, and the view's `WHERE rec NOT IN ('','null')` drops every row. The consumer still advances its offset, so `num_messages_read` climbs steadily while the mirror stays at zero and **nothing reports an error**.

`docker-compose` has always set:

```yaml
CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE: "false"
CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "false"
```

The Kubernetes manifest set `KEY_CONVERTER`/`VALUE_CONVERTER` but **not these**, so the same connector config produced different message shapes in the two environments.

## Verification

Confirmed the expected shape against the working compose topic:

```json
{"before":null,"after":{"order_id":1,"customer_id":16,...},"source":{...}
```

Flat, top-level `before`/`after`/`source` — exactly what the views parse, and exactly what `schemas.enable=false` produces. A wrapped envelope would begin `{"schema":`.

yamllint clean; env parity with compose asserted programmatically.

## Note for the reported cluster

Connect must be restarted to pick this up, and the existing topics still hold wrapped records. Those old messages will never parse, so the useful test after redeploying is a fresh `scripts/test_e2e.sh`, which seeds new rows rather than relying on the backlog.