### PR TITLE
Invoke python3 rather than python in docs and Makefile

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -227,8 +227,8 @@ Step 5 proves the pipelines work once. To watch a continuous stream of new recor
 ```bash
 kubectl port-forward svc/postgres-source 5432:5432 -n etl
 # in another terminal, from the repo root:
-pip install psycopg2-binary
-python scripts/simulate_live_traffic.py --rate 5 --interval 3
+python3 -m pip install psycopg2-binary
+python3 scripts/simulate_live_traffic.py --rate 5 --interval 3
 ```
 
 Leave it running and watch each destination:

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ register-connector:
 
 ## Regenerate pipeline artifacts from airflow/dags/config/pipelines.yml
 generate:
-	python scripts/generate_pipeline_assets.py
+	python3 scripts/generate_pipeline_assets.py
 
 ## Show this help
 help:


### PR DESCRIPTION
Fixes #111.

## What actually happened

```
$ python scripts/simulate_live_traffic.py --rate 5 --interval 3
Traceback (most recent call last):
  File "/usr/lib/command-not-found", line 28, in <module>
    ...
    import apt_pkg
ModuleNotFoundError: No module named 'apt_pkg'
```

Nothing here is our script. On Debian and Ubuntu there is usually **no `python` executable at all** — only `python3`. The shell falls through to Ubuntu's *command-not-found* handler, which on that system is itself broken and raises the `apt_pkg` error.

So the message points at apt, the user had just successfully installed `psycopg2-binary`, and the real cause — a missing interpreter name — is nowhere in the output. Easy to lose an hour on.

## Fix

- `DEPLOY_GUIDE.md` Step 8 now uses `python3 scripts/simulate_live_traffic.py`, and `python3 -m pip install` so the same class of problem cannot bite on `pip` either
- The `generate` target had the identical defect — `make generate` would have failed the same way on Ubuntu

`scripts/test_e2e.sh` already required `python3` explicitly, which is why that path worked for the reporter while the generator did not.

Verified no bare `python` invocations remain for users to run (the one in the `seed` target runs inside a `python:3.11-slim` container, where `python` does exist). Generator still passes `--check`; markdownlint clean.