### PR TITLE
State the real Grafana credentials

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -184,11 +184,22 @@ kubectl get nodes -o wide   # EXTERNAL-IP column; use INTERNAL-IP if blank
 | Airflow (pipeline runs) | `http://NODE_IP:30880` | admin / admin |
 | AI Dashboard (ask questions in English) | `http://NODE_IP:30333` | `DASHBOARD_AUTH_*` from secrets |
 | Kafka UI (topic monitoring) | `http://NODE_IP:30801` | `KAFKA_UI_*` from secrets |
-| Grafana (metrics) | `http://NODE_IP:30300` | admin / admin123 |
+| Grafana (metrics) | `http://NODE_IP:30300` | `AIRFLOW_ADMIN_*` from secrets — see note |
 | MinIO (data files) | `http://NODE_IP:30901` | `MINIO_ROOT_*` from secrets |
 | Spark UI (job progress) | `http://NODE_IP:30808` | — |
 
-Credentials come from `k8s/01-secrets.generated.yaml` if you ran Step 2, otherwise from the defaults in `k8s/01-secrets.yaml`.
+Credentials come from `k8s/01-secrets.generated.yaml` if you ran Step 2, otherwise from the defaults in `k8s/01-secrets.yaml`. Read any of them with:
+
+```bash
+kubectl get secret etl-secrets -n etl -o jsonpath='{.data.MINIO_ROOT_PASSWORD}' | base64 -d
+```
+
+> **Grafana uses the `AIRFLOW_ADMIN_*` keys, not a Grafana-specific pair.** The deployment maps `AIRFLOW_ADMIN_USER`/`AIRFLOW_ADMIN_PASSWORD` onto `GF_SECURITY_ADMIN_USER`/`GF_SECURITY_ADMIN_PASSWORD`, so the two services share one admin credential. It is not `admin/admin123`, and it is not the `DASHBOARD_AUTH_*` pair — those belong to the AI dashboard:
+>
+> ```bash
+> kubectl get secret etl-secrets -n etl -o jsonpath='{.data.AIRFLOW_ADMIN_USER}' | base64 -d; echo
+> kubectl get secret etl-secrets -n etl -o jsonpath='{.data.AIRFLOW_ADMIN_PASSWORD}' | base64 -d; echo
+> ```
 
 **Trino** (no NodePort — port-forward to query the lakehouse):
 

--- a/k8s/monitoring/grafana.yaml
+++ b/k8s/monitoring/grafana.yaml
@@ -62,6 +62,14 @@ spec:
         ports:
         - containerPort: 3000
         env:
+        # Deliberately the AIRFLOW_ADMIN_* keys: Grafana and Airflow share one
+        # admin credential here, and there is no GRAFANA_* key in etl-secrets.
+        # It is surprising enough that people try admin/admin123 (the default
+        # value of AIRFLOW_ADMIN_PASSWORD, which is wrong on any cluster using
+        # generate-secrets.sh) or the DASHBOARD_AUTH_* pair, which belongs to
+        # the AI dashboard. docker-compose reads GRAFANA_ADMIN_* instead, so the
+        # two environments differ; splitting them here would need the new key
+        # added to every existing etl-secrets first, or Grafana fails to start.
         - name: GF_SECURITY_ADMIN_USER
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Fixes #114.

## The problem

`DEPLOY_GUIDE.md` said:

```
| Grafana (metrics) | http://NODE_IP:30300 | admin / admin123 |
```

That is only true on a cluster deployed with the **checked-in defaults**. `admin123` is the default value of `AIRFLOW_ADMIN_PASSWORD` in `k8s/01-secrets.yaml`. On anything deployed with `generate-secrets.sh` — the path the guide recommends — the password is random, so the documented credential cannot work.

And the two other pairs a user would reasonably reach for are both wrong: `DASHBOARD_AUTH_*` belongs to the AI dashboard, and there is **no `GRAFANA_*` key in the secret at all**. The reporter tried both.

## What is actually true

On Kubernetes, Grafana maps `AIRFLOW_ADMIN_USER`/`AIRFLOW_ADMIN_PASSWORD` onto `GF_SECURITY_ADMIN_USER`/`GF_SECURITY_ADMIN_PASSWORD` — it shares one admin credential with Airflow. The guide now says so, with the commands to read the values out of the secret.

## Why I did not just split the credential

`docker-compose` reads `GRAFANA_ADMIN_USER`/`GRAFANA_ADMIN_PASSWORD`, so the two environments genuinely differ — another parity gap, and the tenth of its kind in this repo.

Introducing a `GRAFANA_*` key on the Kubernetes side would break Grafana on **every existing cluster** whose `etl-secrets` predates it: `generate-secrets.sh` refuses to overwrite an existing generated file, so the new key would never appear and the pod would fail on a missing `secretKeyRef`. Given how many migration breaks this project has already absorbed, that is worth doing deliberately with a migration note rather than slipping it into a documentation fix.

The reuse and that reasoning are now recorded in `k8s/monitoring/grafana.yaml` so the next reader is not surprised by it.

yamllint and markdownlint clean.