### PR TITLE
Provide the source, dest and MinIO connections on Kubernetes

### DIFF
--- a/k8s/airflow/helm-values.yaml
+++ b/k8s/airflow/helm-values.yaml
@@ -124,6 +124,12 @@ extraEnv: |
 extraEnvFrom: |
   - secretRef:
       name: etl-secrets
+  # source_postgres, dest_postgres and minio_s3 as AIRFLOW_CONN_* URIs.
+  # deploy.sh builds this secret from the deployed credentials; without it the
+  # DAGs fail immediately on a missing connection. Compose provides the same
+  # set inline (see the x-airflow-connections anchor in docker-compose.yml).
+  - secretRef:
+      name: airflow-connections
 
 extraVolumeMounts:
   - name: dbt-project

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -329,6 +329,20 @@ ok "Monitoring stack is ready"
 
 # ─── Step 9: Airflow ──────────────────────────────────────────────────────────
 echo ""
+# The DAGs resolve their hooks by connection id — source_postgres,
+# dest_postgres and minio_s3 (the Cosmos dbt profile uses dest_postgres too).
+# docker-compose supplies all of these as AIRFLOW_CONN_* env vars; Kubernetes
+# only ever set AIRFLOW_CONN_SPARK_DEFAULT, so every ingest task failed within
+# seconds looking up a connection that did not exist. Built here rather than in
+# the values file because the URIs embed credentials that live in the secret.
+info "Building Airflow connection URIs from the deployed credentials..."
+kubectl create secret generic airflow-connections -n $NAMESPACE \
+  --from-literal=AIRFLOW_CONN_SOURCE_POSTGRES="postgresql://$(secret_val SOURCE_DB_USER):$(secret_val SOURCE_DB_PASSWORD)@postgres-source-0.postgres-source.${NAMESPACE}.svc.cluster.local:5432/$(secret_val SOURCE_DB_NAME)" \
+  --from-literal=AIRFLOW_CONN_DEST_POSTGRES="postgresql://$(secret_val DEST_DB_USER):$(secret_val DEST_DB_PASSWORD)@postgres-dest-0.postgres-dest.${NAMESPACE}.svc.cluster.local:5432/$(secret_val DEST_DB_NAME)" \
+  --from-literal=AIRFLOW_CONN_MINIO_S3="aws://$(secret_val MINIO_ROOT_USER):$(secret_val MINIO_ROOT_PASSWORD)@?endpoint_url=http%3A%2F%2Fminio-0.minio.${NAMESPACE}.svc.cluster.local%3A9000" \
+  --dry-run=client -o yaml | kubectl apply -f -
+ok "Airflow connections published"
+
 info "Adding Airflow Helm repo..."
 helm repo add apache-airflow https://airflow.apache.org --force-update
 helm repo update


### PR DESCRIPTION
Fixes #117 — every ingest task fails within seconds of starting.

## Cause

The DAGs resolve their hooks by connection id:

```python
PostgresHook(postgres_conn_id='source_postgres')
PostgresHook(postgres_conn_id='dest_postgres')
S3Hook(aws_conn_id='minio_s3')
ProfileConfig(... conn_id="dest_postgres")     # Cosmos dbt profile
```

`docker-compose` supplies all of them as `AIRFLOW_CONN_*` env vars via the `x-airflow-connections` anchor. **The Kubernetes values file only ever set `AIRFLOW_CONN_SPARK_DEFAULT`** — so on a cluster none of those connections exist, and each task dies looking one up. That matches the reported 12-second failures across ,  and the rest.

## Why it looked like a logging problem

With `KubernetesExecutor` each task runs in its own pod, and `logs.persistence` is disabled because local-path provisioners do not support `ReadWriteMany`. Once the pod exits, the UI can only say:

```
Could not read served logs: HTTPConnectionPool(host='...-ingest-products-...', port=8793): Max retries exceeded
```

That is the symptom the reporter saw. It reads as a log-serving fault, and it hides the actual exception completely.

## Fix

`deploy.sh` builds the three URIs from the credentials actually deployed and publishes them as the `airflow-connections` secret; the values file pulls it in through `extraEnvFrom` alongside `etl-secrets`. Built in the script rather than the values file so credentials stay out of version control.

## Verified

URI formats checked against `apache/airflow:3.3.0-python3.11`:

```
source_postgres -> conn_type postgres, host postgres-source-0.postgres-source.etl...,
                   schema sourcedb, login sourceuser, port 5432
minio_s3        -> conn_type aws, login minioadmin,
                   extra {'endpoint_url': 'http://minio-0.minio.etl.svc.cluster.local:9000'}
```

`helm template` renders the secret into all 22 pod specs. shellcheck, `bash -n` and yamllint clean.

## Known follow-up

Task logs remain unreadable after a worker pod exits, which is what made this hard to diagnose. Remote logging to the MinIO already in the stack would fix that permanently — worth doing as its own change rather than bundling it here.