### PR TITLE
Ship Airflow task logs to MinIO so failures are diagnosable

### DIFF
--- a/k8s/airflow/helm-values.yaml
+++ b/k8s/airflow/helm-values.yaml
@@ -20,6 +20,22 @@ config:
     auth_manager: "airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager"
   api:
     auth_backends: "airflow.providers.fab.auth_manager.api.auth.backend.basic_auth,airflow.providers.fab.auth_manager.api.auth.backend.session"
+  # Ship task logs to the MinIO already in the stack.
+  #
+  # With KubernetesExecutor each task runs in its own pod and the scheduler
+  # fetches logs from it over port 8793. Log persistence is off because
+  # local-path provisioners cannot do ReadWriteMany, so once the pod exits the
+  # logs are gone and the UI can only report
+  #   Could not read served logs: ... Failed to resolve '<pod>' ...
+  # That message replaces the actual traceback, which makes every task failure
+  # undiagnosable — exactly what happened while chasing the missing connections.
+  #
+  # Writing them to s3://airflow-logs/ via the minio_s3 connection means the
+  # logs outlive the pod and the UI reads them from object storage instead.
+  logging:
+    remote_logging: "True"
+    remote_base_log_folder: "s3://airflow-logs/"
+    remote_log_conn_id: "minio_s3"
 
 images:
   airflow:
@@ -148,6 +164,8 @@ postgresql:
 
 # Disable log persistence for local deployments since local-path provisioners
 # typically do not support the ReadWriteMany (RWX) access mode required by Airflow.
+# Task logs are shipped to MinIO instead — see the logging config above, without
+# which they would be unreadable the moment a worker pod exits.
 logs:
   persistence:
     enabled: false

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -162,7 +162,8 @@ MINIO_POD="minio-0"
 if kubectl exec -n $NAMESPACE "$MINIO_POD" -- sh -c '
   mc alias set local http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" &&
   mc mb --ignore-existing local/bronze &&
-  mc mb --ignore-existing local/silver
+  mc mb --ignore-existing local/silver &&
+  mc mb --ignore-existing local/airflow-logs
 '; then
   ok "MinIO buckets ready"
 else


### PR DESCRIPTION
Unblocks #117, and every future task failure on Kubernetes.

## The problem

```
Could not read served logs: HTTPConnectionPool(host='...-ingest-products-dep80wy2', port=8793)
  ... Failed to resolve 'ingest-source-to-bronze-ingest-products-dep80wy2'
```

With `KubernetesExecutor` every task runs in its own pod, and the scheduler fetches logs from that pod over port 8793. `logs.persistence` is disabled because local-path provisioners cannot provide `ReadWriteMany`. So the instant a task pod exits, its logs are unreachable and **that message replaces the traceback entirely**.

The cost is not theoretical. The missing `AIRFLOW_CONN_*` connections (#118) took a full round trip to identify because the real exception was never visible — and #117 is still open right now with tasks failing for a reason nobody can read.

## Fix

Airflow writes task logs to `s3://airflow-logs/` through the existing `minio_s3` connection, so they outlive the pod and the UI reads them back from object storage. `deploy.sh` creates the bucket alongside `bronze` and `silver`.

Everything this needs was already in the stack:

| Requirement | Already present |
|---|---|
| Object store | MinIO |
| S3 provider | `apache-airflow-providers-amazon` in the runtime image |
| Connection | `minio_s3`, published by `deploy.sh` (#118) |

## Verified

`helm template` renders the settings into `airflow.cfg` where Airflow actually reads them:

```
[logging]
remote_base_log_folder = s3://airflow-logs/
remote_log_conn_id = minio_s3
remote_logging = True
```

shellcheck and yamllint clean.

## Note

This does not fix whatever is failing in #117 — it makes it **visible**. After redeploying, the failing task's log will show the actual exception in the UI instead of the pod-unreachable message, which should turn that issue from guesswork into a one-look diagnosis.