### PR TITLE
fix(monitoring): query the metric names statsd-exporter actually emits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
         run: |
           pip install pyyaml
           python scripts/generate_pipeline_assets.py --check
+      - name: Verify dashboard and alert metrics exist in the statsd mapping
+        run: python scripts/check_dashboard_metrics.py
 
   type-check:
     runs-on: ubuntu-latest

--- a/monitoring/grafana/dashboards/data_platform.json
+++ b/monitoring/grafana/dashboards/data_platform.json
@@ -19,7 +19,7 @@
       "datasource": "Prometheus",
       "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
       "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] } } },
-      "targets": [ { "expr": "sum(rate(airflow_scheduler_heartbeat_total[5m]))", "refId": "A" } ]
+      "targets": [ { "expr": "sum(rate(airflow_scheduler_heartbeat[5m]))", "refId": "A" } ]
     },
     {
       "type": "stat",
@@ -35,8 +35,8 @@
       "datasource": "Prometheus",
       "gridPos": { "h": 6, "w": 12, "x": 12, "y": 1 },
       "targets": [
-        { "expr": "sum(rate(airflow_ti_successes_total[5m]))", "legendFormat": "successes", "refId": "A" },
-        { "expr": "sum(rate(airflow_ti_failures_total[5m]))", "legendFormat": "failures", "refId": "B" }
+        { "expr": "sum(rate(airflow_ti_successes[5m]))", "legendFormat": "successes", "refId": "A" },
+        { "expr": "sum(rate(airflow_ti_failures[5m]))", "legendFormat": "failures", "refId": "B" }
       ]
     },
     {

--- a/scripts/check_dashboard_metrics.py
+++ b/scripts/check_dashboard_metrics.py
@@ -1,0 +1,142 @@
+"""Verify every Airflow/ETL metric queried by Grafana and the alert rules is
+one the statsd-exporter mapping actually emits.
+
+Grafana renders an unknown metric name as an empty panel, and Prometheus
+treats an alert on an unknown name as permanently not-firing. Both fail
+silently, so a typo here is invisible until someone notices a dashboard row
+that has never drawn a line. That is exactly how the "Pipeline Orchestration"
+row shipped querying airflow_ti_successes_total: statsd-exporter emits
+airflow_ti_successes, with no _total suffix, under both the plain-text and
+the OpenMetrics negotiation Prometheus uses.
+
+Only airflow_*/etl_* names are checked — those are the ones the mapping owns.
+kafka_*, minio_* and node_* come from their own exporters.
+
+Run: python scripts/check_dashboard_metrics.py
+"""
+
+import glob
+import json
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MAPPING = os.path.join(ROOT, 'monitoring', 'statsd_mapping.yml')
+# Kubernetes gets the same mappings via the Airflow chart's statsd
+# overrideMappings. If the two drift, the check below still passes while the
+# dashboards go blank on the cluster only — the parity failure this repo keeps
+# hitting — so compare them rather than trusting one file.
+HELM_VALUES = os.path.join(ROOT, 'k8s', 'airflow', 'helm-values.yaml')
+
+# Suffixes statsd-exporter genuinely appends when a mapping produces a
+# summary/histogram (Airflow's timers), so alert rules may legitimately use
+# them: airflow.dagrun.duration.failed.* -> airflow_dagrun_duration_failed_count.
+DERIVED_SUFFIXES = ('_count', '_sum', '_bucket', '_created')
+
+OWNED = re.compile(r'\b((?:airflow|etl)_[a-z0-9_]+)')
+
+
+PAIR = re.compile(r'match:\s*["\']([^"\']+)["\'][\s\S]{0,80}?name:\s*["\']([A-Za-z0-9_]+)')
+
+
+def mapping_pairs(path, after=None):
+    with open(path, encoding='utf-8') as fh:
+        text = fh.read()
+    if after:
+        text = text[text.find(after):]
+    return set(PAIR.findall(text))
+
+
+def emitted_names():
+    with open(MAPPING, encoding='utf-8') as fh:
+        return set(re.findall(r'^\s*name:\s*["\']?([A-Za-z0-9_]+)', fh.read(), re.M))
+
+
+def mapping_drift():
+    """statsd mappings that exist in one environment but not the other."""
+    compose = mapping_pairs(MAPPING)
+    k8s = mapping_pairs(HELM_VALUES, after='overrideMappings')
+    return sorted(compose - k8s), sorted(k8s - compose)
+
+
+def queried():
+    """(metric, source-file) for every airflow_*/etl_* name we query."""
+    found = []
+
+    for path in glob.glob(os.path.join(ROOT, 'monitoring', 'grafana',
+                                       'dashboards', '*.json')):
+        with open(path, encoding='utf-8') as fh:
+            dash = json.load(fh)
+        for panel in dash.get('panels', []):
+            for target in panel.get('targets', []):
+                for name in OWNED.findall(target.get('expr', '')):
+                    found.append((name, os.path.basename(path)))
+
+    # Alert rules live inline in the compose config and again in the k8s
+    # ConfigMap; both are plain `expr:` lines, so scan them as text rather
+    # than taking a YAML dependency for two files.
+    for rel in ('monitoring/alert_rules.yml', 'k8s/02-configmaps.yaml'):
+        path = os.path.join(ROOT, rel)
+        if not os.path.exists(path):
+            continue
+        with open(path, encoding='utf-8') as fh:
+            for line in fh:
+                if 'expr:' in line:
+                    for name in OWNED.findall(line):
+                        found.append((name, rel))
+
+    return found
+
+
+def resolves(name, names):
+    if name in names:
+        return True
+    return any(name.endswith(s) and name[:-len(s)] in names
+               for s in DERIVED_SUFFIXES)
+
+
+def main():
+    names = emitted_names()
+    if not names:
+        sys.exit(f"No mappings parsed from {MAPPING} — has the format changed?")
+
+    bad = sorted({(m, src) for m, src in queried() if not resolves(m, names)})
+    if bad:
+        print("Metrics queried but never emitted by statsd_mapping.yml:\n")
+        for metric, src in bad:
+            print(f"  {metric}\n      queried in {src}")
+            stem = metric
+            for suffix in ('_total',) + DERIVED_SUFFIXES:
+                if stem.endswith(suffix) and stem[:-len(suffix)] in names:
+                    print(f"      did you mean {stem[:-len(suffix)]}?")
+                    break
+        print("\nstatsd-exporter emits mapping names verbatim; it does not add"
+              " a _total suffix to counters.")
+        sys.exit(1)
+
+    only_compose, only_k8s = mapping_drift()
+    if only_compose or only_k8s:
+        print("statsd mappings differ between compose and Kubernetes, so the "
+              "dashboards cannot match in both:\n")
+        for match, name in only_compose:
+            print(f"  only in monitoring/statsd_mapping.yml: {match} -> {name}")
+        for match, name in only_k8s:
+            print(f"  only in k8s/airflow/helm-values.yaml:  {match} -> {name}")
+        sys.exit(1)
+
+    print(f"OK - every airflow_*/etl_* metric queried resolves "
+          f"({len(names)} mappings, compose and k8s agree).")
+
+
+def _self_check():
+    names = {'airflow_ti_successes', 'airflow_dagrun_duration_failed'}
+    assert resolves('airflow_ti_successes', names)
+    assert resolves('airflow_dagrun_duration_failed_count', names)  # timer
+    assert not resolves('airflow_ti_successes_total', names)        # the bug
+    assert not resolves('airflow_nope', names)
+
+
+if __name__ == '__main__':
+    _self_check()
+    main()


### PR DESCRIPTION
Raghu posted the Data Platform Health dashboards on #111. Both screenshots are the **Real-Time CDC** row, and both are full of data — consumer lag rising and returning to zero, `cdc.public.orders` and `cdc.public.order_items` tracking the traffic generator. Pipe 3 and kafka-exporter are working.

The **Pipeline Orchestration** row is missing from those screenshots, and it turns out it has never drawn a line — in either environment.

## Cause

Three panels query names with a `_total` suffix:

```
airflow_scheduler_heartbeat_total
airflow_ti_successes_total
airflow_ti_failures_total
```

statsd-exporter emits mapping names verbatim and does **not** append `_total` to counters. Verified against `prom/statsd-exporter` using this repo's own `statsd_mapping.yml`, feeding it real Airflow counters:

```
$ curl -s localhost:9102/metrics | grep ^airflow_
airflow_scheduler_heartbeat 1
airflow_ti_failures 1
airflow_ti_successes 3
```

Identical under `Accept: application/openmetrics-text` — the negotiation Prometheus actually performs, and the only plausible route to a `_total` suffix. So the queries match nothing and Grafana renders an empty panel.

`_total` appeared nowhere else in the repo. The alert rules already use the correct names, including the `_count` suffix statsd-exporter *does* derive for Airflow's timers.

## Why it stayed hidden

An unknown metric name fails silently at both ends: Grafana draws an empty panel, and Prometheus treats an alert on an unknown name as permanently not-firing. Neither logs anything. With Pipes 1 and 2 blocked behind #117, an empty orchestration row also looks exactly like the expected symptom of "no DAGs have run" — so the real defect was fully camouflaged.

## Check

`scripts/check_dashboard_metrics.py`, wired into the existing `pipeline-config-sync` job. It resolves every `airflow_*`/`etl_*` metric queried by a dashboard or alert rule against the mapping, allowing the suffixes statsd-exporter genuinely derives:

```
$ python scripts/check_dashboard_metrics.py     # before
airflow_ti_successes_total
    queried in data_platform.json
    did you mean airflow_ti_successes?
```

It also asserts the compose mapping and the chart's `overrideMappings` still agree. Without that second arm the check reads only the compose file, so a k8s-only rename would leave the dashboards blank on the cluster while CI stayed green — the parity failure mode this repo keeps hitting.

Both arms verified by deliberately reintroducing each fault. Dependency-free; ruff clean.

## Scope

Does not touch #117 — those panels stay empty until DAG tasks actually run. This makes them capable of showing data once they do.