### PR TITLE
fix(ingest): check the source schema before extracting

### DIFF
--- a/airflow/dags/ingest_source_to_bronze.py
+++ b/airflow/dags/ingest_source_to_bronze.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta
 import pandas as pd
 
 from airflow import DAG
+from airflow.exceptions import AirflowException
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
@@ -28,6 +29,47 @@ sys.path.insert(0, str(Path(__file__).parent))
 from pipeline_config import load_manifest, raw_ddl  # noqa: E402
 
 log = logging.getLogger(__name__)
+
+
+def check_source_schema(source_hook, table_name, needed):
+    """Fail with a legible message if the source lacks a manifested column.
+
+    The extract selects the manifest's column list verbatim. When the source
+    predates the manifest the query dies inside pandas with a bare
+
+        psycopg2.errors.UndefinedColumn: column "name" does not exist
+
+    naming one column, buried under a SQLAlchemy traceback, and offering no
+    remedy — the same trap simulate_live_traffic.py already guards against.
+    Checking up front names every missing column at once and says what to do.
+    """
+    rows = source_hook.get_records(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_schema = 'public' AND table_name = %s",
+        parameters=(table_name,),
+    )
+    present = {r[0] for r in rows}
+    if not present:
+        raise AirflowException(
+            f"Source table '{table_name}' does not exist. Seed the source "
+            f"first: make seed (or re-run k8s/deploy.sh and answer y when it "
+            f"offers to seed)."
+        )
+
+    missing = [c for c in needed if c not in present]
+    if missing:
+        raise AirflowException(
+            f"Source table '{table_name}' is missing {', '.join(missing)}, "
+            f"which airflow/dags/config/pipelines.yml expects.\n"
+            f"  present: {', '.join(sorted(present))}\n"
+            f"This means the source was seeded by an older version of "
+            f"sample-data/generate_ecommerce.py. Re-seed to bring it in line "
+            f"(this drops and recreates the source tables, so the Debezium "
+            f"slot and the ClickHouse mirror restart from empty):\n"
+            f"  make seed\n"
+            f"On Kubernetes, re-run bash k8s/deploy.sh and answer y when it "
+            f"offers to seed."
+        )
 
 # Single source of truth for tables: airflow/dags/config/pipelines.yml
 MANIFEST = load_manifest()
@@ -111,6 +153,9 @@ def extract_and_load_table(table_name, **kwargs):
     dest_hook.run(raw_ddl(table_name, config))
 
     # 2. Extract from Source (Incremental CDC Logic)
+    # The cursor is filtered on as well as selected, so it has to exist too.
+    check_source_schema(source_hook, table_name,
+                        columns + ([cursor_col] if cursor_col else []))
     cols_str = ",".join(columns)
 
     # 2a. Fetch the high-water mark (MAX cursor) from the Destination staging DB


### PR DESCRIPTION
Found while trying to narrow #117 without waiting on a traceback. **The failure reproduces in Docker Compose** — every `ingest_source_to_bronze` run on my local stack has failed going back to 4 July. It is not Kubernetes-specific.

## The actual error

```
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedColumn)
column "name" does not exist
LINE 1: SELECT product_id,name,description,price,category,stock_quan...

[SQL: SELECT product_id,name,description,price,category,stock_quantity,created_at,updated_at
      FROM products WHERE updated_at > '...' ORDER BY product_id]
```

The source `products` table carried `product_name, category, price, created_at`; `pipelines.yml` expects `name, description, stock_quantity, updated_at`. The source had been seeded by an older generator.

Re-seeding fixed it and all four extracts passed:

```
ingest_products    -> PASS
ingest_customers   -> PASS
ingest_orders      -> PASS
ingest_order_items -> PASS
```

So the extract logic was never at fault. The defect is that it fails *unreadably* when the source drifts.

## Why this matters beyond one bad database

The extract dies inside pandas on a bare driver error naming **one** column, under a SQLAlchemy traceback, with no statement of what the pipeline expected or how to repair it. Every downstream task then reports `upstream_failed`, so the visible symptom is "the DAG failed" and the cause is four frames deep.

`simulate_live_traffic.py` already guards against exactly this drift — that was #119, same root cause on `order_items` (`price` vs `unit_price`). The DAG that hits the same drift never got the same guard. This closes that asymmetry.

## After

```
AirflowException: Source table 'products' is missing name, which
airflow/dags/config/pipelines.yml expects.
  present: category, created_at, description, price, product_id,
           product_name, stock_quantity, updated_at
This means the source was seeded by an older version of
sample-data/generate_ecommerce.py. Re-seed to bring it in line (this drops
and recreates the source tables, so the Debezium slot and the ClickHouse
mirror restart from empty):
  make seed
On Kubernetes, re-run bash k8s/deploy.sh and answer y when it offers to seed.
```

Every missing column at once, what the table actually has, and the remedy for both environments — including the warning that re-seeding restarts CDC from empty, which matters now that Pipe 3 is live.

The cursor column is checked too: it is filtered on as well as selected, so a `products` without `updated_at` would otherwise pass the column check and fail in the `WHERE` clause instead.

## Verified

Precheck fires on a deliberately renamed column, then passes once restored; all four extracts green. ruff clean.

## Note on CI

The smoke test runs `DEPLOY_PROFILE=core`, which stops before Airflow — so **no CI job has ever executed Pipe 1**. That is why this survived. Worth a follow-up; not in this PR, since running Airflow in CI is a much larger job than the fix.