### PR TITLE
fix: make Pipes 1 and 2 actually run

### DIFF
--- a/airflow/dags/spark_transform_silver.py
+++ b/airflow/dags/spark_transform_silver.py
@@ -101,7 +101,13 @@ with DAG(
             # compact 24 times instead of once. -u pins the comparison to UTC
             # (Airflow's logical time) so it cannot drift with container TZ.
             'if [ "$(date -u -d \'{{ ts }}\' +%u%H)" = "700" ]; then '
-            + get_spark_submit_command('Iceberg-Maintenance', '/opt/spark-jobs/iceberg_maintenance.py')
+            # .strip() matters: the builder's f-string ends with a newline and
+            # indent, so without it the "; else" lands on its own line starting
+            # with a semicolon -- a bash syntax error that exits 2 before the
+            # gate is ever evaluated. The other tasks pass the string through
+            # as a whole command, where the stray whitespace is harmless, so
+            # only this composed one breaks.
+            + get_spark_submit_command('Iceberg-Maintenance', '/opt/spark-jobs/iceberg_maintenance.py').strip()
             + '; else echo "Skipping Iceberg maintenance — runs Sundays at 00:00 only"; fi'
         ),
         # Run only on Sundays to optimize storage after weekly activity

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,18 @@
-# Airflow connections shared by webserver, scheduler and dag-processor.
-# Provisioned via AIRFLOW_CONN_* env vars so no manual UI setup is needed.
+# Airflow env shared by webserver, scheduler and dag-processor.
+# Connections are provisioned via AIRFLOW_CONN_* so no manual UI setup is
+# needed. The JWT secret lives here too, because its whole purpose is to be
+# identical across the three services -- copying it into each would invite
+# exactly the drift it exists to prevent.
 x-airflow-connections: &airflow-connections
+  # Airflow 3 tasks authenticate to the Task Execution API with a JWT the
+  # scheduler signs and the API server verifies. Unset, each process invents
+  # its own secret, every task dies with
+  #   airflow.sdk.api.client.ServerResponseError: Invalid auth token
+  # and the scheduler only reports "finished with state failed, but the task
+  # instance's state attribute is queued" -- which reads like a scheduling
+  # race, not an auth failure. Kubernetes is unaffected: the Airflow chart
+  # generates and shares one for us.
+  AIRFLOW__API_AUTH__JWT_SECRET: ${AIRFLOW_JWT_SECRET:-etl-local-jwt-secret-change-in-production}
   AIRFLOW_CONN_SPARK_DEFAULT: spark://spark-master:7077
   AIRFLOW_CONN_SOURCE_POSTGRES: >-
     postgresql://${SOURCE_DB_USER:-sourceuser}:${SOURCE_DB_PASSWORD:-sourcepass}@postgres-source:5432/${SOURCE_DB_NAME:-sourcedb}
@@ -430,6 +442,17 @@ services:
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
       AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
       AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS: 'True'
+      # Airflow 3 runs every task through the Task Execution API rather than
+      # letting it reach the metadata database directly. LocalExecutor forks
+      # the task inside THIS container, so the default of localhost:8080 points
+      # at nothing here -- the API server is the separate airflow-webserver
+      # service. Without this, every task dies before it starts with
+      #   httpx.ConnectError: [Errno 111] Connection refused
+      # and the scheduler reports "finished with state failed, but the task
+      # instance's state attribute is queued", which reads like a scheduling
+      # race rather than a missing address. Kubernetes is unaffected: the
+      # Airflow chart wires this to its own api-server service.
+      AIRFLOW__CORE__EXECUTION_API_SERVER_URL: http://airflow-webserver:8080/execution/
       SOURCE_DB_USER: ${SOURCE_DB_USER:-sourceuser}
       SOURCE_DB_PASSWORD: ${SOURCE_DB_PASSWORD:-sourcepass}
       SOURCE_DB_NAME: ${SOURCE_DB_NAME:-sourcedb}

--- a/docker/airflow/requirements-airflow.txt
+++ b/docker/airflow/requirements-airflow.txt
@@ -6,8 +6,23 @@ minio>=7.2.0
 dbt-core>=1.7.0
 dbt-postgres>=1.7.0
 sqlalchemy>=1.4.51
-apache-airflow-providers-apache-spark>=4.5.0
-pyspark>=3.5.0
+# Capped below 6.0: from 6.x this provider depends on pyspark-client>=4.0.0,
+# which ships the Spark 4 Connect client under the same `pyspark` module name
+# and shadows the real pyspark below, so `import pyspark` reports 4.2.0 no
+# matter what the pin below says. That is what actually broke Spark jobs --
+# the pyspark pin alone does not hold without this cap.
+apache-airflow-providers-apache-spark>=4.5.0,<6.0.0
+# Must match the cluster exactly, not just be "at least" it. The Spark master
+# and workers are built FROM apache/spark:3.5.0 (Scala 2.12), and Spark's RPC
+# layer checks serialVersionUID on every message. A floating >=3.5.0 resolved
+# to pyspark 4.2.0 once Spark 4 was released, which is Scala 2.13, so every
+# job died with
+#   java.io.InvalidClassException: ... local class incompatible
+#   java.lang.ClassNotFoundException: scala.Serializable
+# This is a time bomb rather than a typo: it was correct when written and
+# broke on its own the day a new major landed on PyPI. Bump this and
+# docker/spark/Dockerfile together.
+pyspark==3.5.0
 apache-airflow-providers-postgres>=5.9.0
 apache-airflow-providers-amazon>=8.13.0
 astronomer-cosmos>=1.3.1


### PR DESCRIPTION
Answering "are we still waiting for Pipes 1 and 2" by running them locally rather than waiting. **Neither has ever completed in Docker Compose.** Every `ingest_source_to_bronze` run has failed since 4 July, and `spark_transform_silver` with it.

Four independent faults, each hidden behind the previous one — fixing any three still leaves you with a red DAG.

## 1. Task Execution API address

Airflow 3 routes every task through the Task Execution API rather than the metadata DB. LocalExecutor forks the task inside the **scheduler** container, where the default `localhost:8080` is nothing — the API server is the separate `airflow-webserver` service.

```
httpx.ConnectError: [Errno 111] Connection refused
```

The scheduler only surfaced `finished with state failed, but the task instance's state attribute is queued`, which reads like a scheduling race rather than a missing address.

## 2. Shared JWT secret

That API authenticates with a JWT the scheduler signs and the API server verifies. Unset, each process invents its own:

```
airflow.sdk.api.client.ServerResponseError: Invalid auth token
```

It goes in the shared YAML anchor because *being identical across the three services* is the whole point — copying it three times invites exactly the drift it prevents.

## 3. Spark client/cluster mismatch

`apache-airflow-providers-apache-spark` was unbounded and floated to **6.3.0**, which depends on `pyspark-client>=4.0.0` — the Spark 4 Connect client, published under the same `pyspark` module name. It shadows the pinned pyspark:

```
pyspark module : 4.2.0     ← against a 3.5.0 cluster
java.io.InvalidClassException: ... local class incompatible
java.lang.ClassNotFoundException: scala.Serializable   ← Spark 4 is Scala 2.13
```

**Capping the provider below 6.0 is what actually fixes this** — pinning `pyspark==3.5.0` alone does not hold, because the shadowing package still wins. After the cap:

```
pyspark module : 3.5.0
pyspark-client : NOT INSTALLED
provider       : 5.2.1
```

The Dockerfile already said *"PySpark 3.5.0 bundles Hadoop 3.3.4 — versions must match"*, so 3.5.0 was always the intent; `>=` quietly defeated it the day Spark 4 landed on PyPI. This is a time bomb, not a typo: correct when written, broken by the calendar.

## 4. Bash syntax in the maintenance gate

`get_spark_submit_command` returns a string ending in a newline and indent. Composing it into a conditional put `; else` on its own line beginning with a semicolon — a bash syntax error, `exit 2`, before the gate was ever evaluated. Only the composed command was affected; the other tasks pass the string through whole, where the trailing whitespace is harmless.

## Verified end to end

Against a freshly seeded source:

```
ingest_source_to_bronze   25/25 tasks succeeded   (dbt models and tests included)
spark_transform_silver     5/5 tasks succeeded
```

Iceberg tables queryable through Trino, counts matching the source exactly:

| Table | Rows |
|---|---|
| `iceberg.lake.orders` | 10,000 |
| `iceberg.lake.order_items` | 19,995 |
| `iceberg.lake.customers` | 100 |
| `iceberg.lake.products` | 50 |

## Scope

Kubernetes is unaffected by 1 and 2 — the Airflow chart wires the API URL and generates a shared secret itself. **3 and 4 apply to both environments**, so this is also a partial fix for #117 independent of the schema drift found earlier.