### PR TITLE
docs(deploy): add a mirror-watch loop to Step 8

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -242,11 +242,30 @@ python3 -m pip install psycopg2-binary
 python3 scripts/simulate_live_traffic.py --rate 5 --interval 3
 ```
 
+**Watch the mirror keep up.** In a third terminal, poll the source and the mirror together. Any gap between the two columns is the live end-to-end CDC lag:
+
+```bash
+CH_USER=$(kubectl get secret etl-secrets -n etl -o jsonpath='{.data.CLICKHOUSE_USER}' | base64 -d)
+CH_PASS=$(kubectl get secret etl-secrets -n etl -o jsonpath='{.data.CLICKHOUSE_PASSWORD}' | base64 -d)
+
+for _ in $(seq 1 20); do
+  src=$(kubectl exec -n etl postgres-source-0 -- \
+          bash -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc "SELECT count(*) FROM orders"')
+  mir=$(kubectl exec -n etl clickhouse-0 -- clickhouse-client \
+          --user "$CH_USER" --password "$CH_PASS" \
+          -q "SELECT count() FROM mirror.orders_current")
+  echo "$(date +%T)  source: ${src// /}  mirror: ${mir}  behind: $(( ${src// /} - mir ))"
+  sleep 5
+done
+```
+
+Expect the mirror to trail by a few seconds and never fall further behind. Steady lag means the consumer is keeping up; lag that grows run after run is the signal something is wrong. The gap itself is mostly ClickHouse's `stream_flush_interval_ms` (7.5s by default), so a few seconds is normal and not a sign of trouble.
+
 Leave it running and watch each destination:
 
 | Pipeline | Where to look | When it moves |
 |---|---|---|
-| **3 · Real-time mirror** | `mirror.orders_current` in ClickHouse (command above) — rerun it and the count climbs | seconds |
+| **3 · Real-time mirror** | `mirror.orders_current` in ClickHouse — the loop above, or rerun the count by hand | seconds |
 | **1 · Warehouse** | `raw.orders_source`, then `int`/`gold` after dbt runs | on the hourly run |
 | **2 · Lakehouse** | `iceberg.lake.orders` via Trino | on the hourly run, after the silver DAG follows ingestion |
 


### PR DESCRIPTION
Closes #123.

Step 8 is about watching a continuous stream land in all three destinations, but for the mirror it said *"rerun it and the count climbs"* — manual polling. Raghu wrote a loop to do it properly while producing the Pipe 3 demonstration in #115, and it belongs in the guide.

Two changes to the version in the issue.

**Quote the credentials.** The original built a command string and relied on word splitting to re-expand it:

```bash
CH="kubectl exec ... --password $(...)"
$CH -q 'SELECT ...'
```

That breaks the moment a password from `generate-secrets.sh` contains a space or a glob character — and it fails confusingly, since the error surfaces as a ClickHouse auth failure rather than a quoting bug. Reading the two secrets into variables and quoting them at point of use removes that entirely.

**Poll the source alongside the mirror.** The #115 demonstration needed two terminals compared by eye. Printing both counts and their difference on one line makes the lag directly visible:

```
21:04:11  source: 1251  mirror: 1246  behind: 5
```

That turns "is it keeping up" from a judgement call into a number, and it is the actual claim Step 8 is making.

I also noted what a healthy reading looks like — a few seconds of *steady* lag, dominated by ClickHouse's default `stream_flush_interval_ms` of 7.5s. Without that, a non-zero gap reads as a fault when it is just the flush timer. The distinction that matters is steady versus growing.

Verified `bash -n` clean, and checked the arithmetic against padded and unpadded `psql` output.