### PR TITLE
fix(airflow): delete failed worker pods so the node cannot fill

### DIFF
--- a/k8s/airflow/helm-values.yaml
+++ b/k8s/airflow/helm-values.yaml
@@ -36,6 +36,22 @@ config:
     remote_logging: "True"
     remote_base_log_folder: "s3://airflow-logs/"
     remote_log_conn_id: "minio_s3"
+  # Delete worker pods when a task FAILS, not just when it succeeds.
+  #
+  # Airflow keeps failed worker pods by default so their logs can be read
+  # after the fact. With KubernetesExecutor and a DAG that fails on a
+  # schedule, that is unbounded growth: every hourly run leaves another dead
+  # pod behind, and each one holds its container writable layer on the node.
+  # A spark-submit pod resolves ~1GB of Ivy jars into that layer, so a
+  # repeatedly failing Spark task fills the node's ephemeral storage, the
+  # kubelet starts evicting, and the eviction SIGTERMs the next Spark run --
+  # which fails, leaves another pod, and tightens the spiral.
+  #
+  # Safe to turn on only because task logs now go to MinIO (see logging
+  # above): the logs outlive the pod, so keeping the corpse buys nothing.
+  kubernetes_executor:
+    delete_worker_pods: "True"
+    delete_worker_pods_on_failure: "True"
 
 images:
   airflow:


### PR DESCRIPTION
Fixes the mechanism behind #126, and explains #117.

## What happened

The node ran out of ephemeral storage. The kubelet declared `DiskPressure` and evicted pods — including `airflow-api-server`:

```
Status:  Failed
Reason:  Evicted
Message: The node was low on resource: ephemeral-storage.
```

`airflow-scheduler` and `airflow-dag-processor` went the same way, and a dbt task pod was rejected outright with `The node had condition: [DiskPressure]`.

In Airflow 3 every task talks to the Task Execution API. With the api-server evicted, task pods came up, retried four times and died:

```
"event":"Starting call to 'Client.request', this is the 4th time calling it."
"exc_type":"ConnectError","exc_value":"[Errno 111] Connection refused"
"event":"Process exited","exit_code":-9,"signal_sent":"SIGKILL"
```

So the `Error` ingest pods in #126 are **collateral, not broken tasks**. They had nothing to talk to.

## Why the disk filled

Airflow keeps failed worker pods by default (`delete_worker_pods_on_failure = False`) so their logs remain readable. With KubernetesExecutor and a DAG failing hourly, that is unbounded growth — every run leaves another dead pod holding its container writable layer, and a `spark-submit` pod resolves ~1GB of Ivy jars into that layer.

The reporter had **eleven** retained `spark-transform-silver-transform-orders-*` pods.

It is self-reinforcing: less disk → more eviction → eviction SIGTERMs the next Spark run → another retained pod. That `-15` exit in #117 is this same event seen from the task's side, not a Spark fault. His log confirms `Running Spark version 3.5.0`, so #124's fix landed and that problem is genuinely solved.

## The change

```yaml
kubernetes_executor:
  delete_worker_pods: "True"
  delete_worker_pods_on_failure: "True"
```

**This is only safe because of #120.** Task logs now go to MinIO, so they outlive the pod — deleting it no longer destroys the evidence, which is the entire reason the default is `False`. Without remote logging this change would trade one debugging problem for another.

## Not included

This does not remove the ~1GB Ivy download per run. Baking `iceberg-spark-runtime` and `postgresql` into both images and dropping `--packages` would, but those jars are needed on the Spark workers as well as the driver, so it is a larger change and left as follow-up. With pod cleanup in place the storage is reclaimed each run, which is what stops the spiral.

YAML and yamllint clean.