### PR TITLE
fix(spark): advertise the driver's IP so executors can reach it

### DIFF
--- a/airflow/dags/spark_transform_silver.py
+++ b/airflow/dags/spark_transform_silver.py
@@ -50,9 +50,29 @@ with DAG(
 
     # Helper function to generate standardized spark-submit commands
     def get_spark_submit_command(job_name, script_path, additional_args=""):
+        # spark.driver.host: advertise the driver's IP, not its hostname.
+        #
+        # These run in client mode, so the driver lives in whatever container
+        # Airflow gave the task and every executor has to open a connection
+        # back to it. Left unset, Spark advertises the local hostname. Under
+        # docker-compose that is the container name and Docker's DNS resolves
+        # it, so this works and hides the problem. Under KubernetesExecutor it
+        # is the task pod's name -- and a bare pod has no Service, so nothing
+        # in the cluster can resolve it. Executors then launch with
+        #   --driver-url spark://CoarseGrainedScheduler@<task-pod-name>:<port>
+        # fail to reach it, and die with "Command exited with code 1". The
+        # master immediately grants a replacement, which dies the same way:
+        # one cluster reached executor ID 45962 before anyone noticed, while
+        # the driver sat logging "Initial job has not accepted any resources"
+        # and the workers looked idle because they were, between deaths.
+        #
+        # The pod IP is routable, so pin to it. bindAddress stays 0.0.0.0 so
+        # the driver still listens on all interfaces inside the container.
         return f"""
     spark-submit \
         --master {SPARK_MASTER_URL} \
+        --conf spark.driver.host=$(hostname -i | cut -d' ' -f1) \
+        --conf spark.driver.bindAddress=0.0.0.0 \
         --conf spark.executor.memory=2g \
         --conf spark.executor.cores=2 \
         --conf spark.sql.adaptive.enabled=true \


### PR DESCRIPTION
Root cause of the Spark hang in #126 / #117. Found it in the executor's own stderr on the worker.

## The evidence

```
"--driver-url" "spark://CoarseGrainedScheduler@spark-transform-silver-transform-orders-1rqe82s7:36323"
```

That hostname is the **Airflow task pod's name**. A bare pod has no Service, so nothing in the cluster can resolve it. The executor log stops right after `SecurityManager` — the next step is contacting the driver.

These jobs run in **client mode**, so the driver lives in the task container and every executor opens a connection *back* to it. With `spark.driver.host` unset, Spark advertises the local hostname:

- **compose** → the container name, which Docker's DNS resolves. Pipe 2 passes locally, and the defect stays invisible.
- **Kubernetes** → the task pod name, which resolves nowhere.

## Why every symptom pointed the wrong way

Executors launched, failed to reach the driver, exited 1. The master granted a replacement instantly, which died identically. The reporting cluster reached **executor ID 45962** — roughly 46,000 launches in 20 hours.

Meanwhile the driver logged `Initial job has not accepted any resources` and the Spark master showed `2 (0 Used)` on both workers. That combination reads exactly like a scheduling or capacity problem, which is what I chased — first zombie executors holding cores, then an unsatisfiable memory request. The workers really were idle; we were sampling between deaths.

## The fix

```
--conf spark.driver.host=$(hostname -i | cut -d' ' -f1)
--conf spark.driver.bindAddress=0.0.0.0
```

Pod IPs are routable, hostnames are not. `bindAddress` stays `0.0.0.0` so the driver still listens on all interfaces inside the container.

## Verified

`spark_transform_silver` still passes end to end locally, and the worker now records an address instead of a name:

```
before:  spark://CoarseGrainedScheduler@spark-transform-silver-transform-orders-1rqe82s7:36323
after:   spark://CoarseGrainedScheduler@172.18.0.21:34317
```

## Not in this PR

The k8s manifests run `bitnamilegacy/spark:3.5.1` while compose builds `apache/spark:3.5.0` — driver and cluster differ by a patch release, from different distributions. I checked and ruled it out as the cause: the executors were dying on the callback address, and that image does carry the S3A jars the classpath points at. Still worth closing separately, since two environments running different Spark builds is how #124 happened.