### PR TITLE
fix(spark): run the same Spark version on the cluster as the driver

### DIFF
--- a/k8s/spark/master-deployment.yaml
+++ b/k8s/spark/master-deployment.yaml
@@ -16,7 +16,16 @@ spec:
     spec:
       containers:
       - name: spark-master
-        image: bitnamilegacy/spark:3.5.1-debian-12-r9
+        # Must be the same Spark version as the driver. The Airflow image
+        # pins pyspark==3.5.0 (see docker/airflow/requirements-airflow.txt),
+        # and Spark checks serialVersionUID on every object crossing the
+        # wire, so a 3.5.1 cluster rejects a 3.5.0 driver's RDDs with
+        #   java.io.InvalidClassException: org.apache.spark.rdd.RDD;
+        #   local class incompatible
+        # Executors start, register, take a task and die on the first
+        # deserialization -- so it presents as a task failure, not a version
+        # problem. Bump this and the pyspark pin together, never alone.
+        image: bitnamilegacy/spark:3.5.0
         env:
         - name: SPARK_MODE
           value: master

--- a/k8s/spark/worker-deployment.yaml
+++ b/k8s/spark/worker-deployment.yaml
@@ -15,7 +15,9 @@ spec:
     spec:
       containers:
       - name: spark-worker
-        image: bitnamilegacy/spark:3.5.1-debian-12-r9
+        # Same Spark version as the driver and the master -- see the note in
+        # master-deployment.yaml. A mismatch here is what executors die on.
+        image: bitnamilegacy/spark:3.5.0
         env:
         - name: SPARK_MODE
           value: worker


### PR DESCRIPTION
The next layer under #129, and the one I flagged as out of scope there.

## What changed after #129

With the driver-host fix in place, executors on the reporting cluster now **start, register and accept a task** — real progress from 46,000 instant deaths. They then die on the first object they deserialize:

```
java.io.InvalidClassException: org.apache.spark.rdd.RDD; local class incompatible:
  stream classdesc serialVersionUID = 823754013007382808
  local class     serialVersionUID = 3516924559342767982
```

The k8s manifests pinned `bitnamilegacy/spark:3.5.1` while the Airflow image pins `pyspark==3.5.0`. Spark checks `serialVersionUID` on every object crossing the wire and makes no compatibility promise across 3.5.x patch releases.

## Verified by experiment, not inference

Same driver image, two clusters differing only in Spark version:

| Driver | Cluster | Result |
|---|---|---|
| pyspark 3.5.0 | `bitnamilegacy/spark:3.5.1` | `InvalidClassException`, task failed 4 times |
| pyspark 3.5.0 | `bitnamilegacy/spark:3.5.0` | `RESULT_COUNT: 10` |

The first row reproduces the reported failure exactly.

I also checked the 3.5.0 tag carries what the manifests expect — `spark-core_2.12-3.5.0.jar`, plus `hadoop-aws-3.3.4.jar` and `aws-java-sdk-bundle-1.12.262.jar` at the path `SPARK_EXTRA_CLASSPATH` points to — so nothing else has to move.

## Why compose never caught it

There, cluster and driver both come from `apache/spark:3.5.0` and `pyspark==3.5.0`. Only the Kubernetes path had a second, unrelated Spark build in it. Same shape as #124, where an unpinned provider dragged a Spark 4 client in behind a 3.5.0 pin — a version mismatch that only exists in one environment, presenting as something other than a version problem.

Worth noting how this one hides: executors die on a *task*, not at startup, so it reads as a job failure rather than a version incompatibility.

## Follow-up not taken here

Kubernetes pulls a Bitnami image while compose builds `apache/spark:3.5.0` from `docker/spark/Dockerfile`. Aligning the version closes the bug, but the two environments still run different Spark *distributions*. Building and pushing our own Spark image the way `deploy.sh` already does for Airflow would remove the whole category. Left separate — it needs a `deploy.sh` change and cannot be validated without a cluster.

A comment on each manifest says to bump this together with the pyspark pin.