### PR TITLE
fix(k8s): create the iceberg_catalog schema Kubernetes never had

### DIFF
--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -146,6 +146,20 @@ info "Waiting for postgres-dest to be ready..."
 kubectl rollout status statefulset/postgres-dest -n $NAMESPACE --timeout=300s
 ok "PostgreSQL pods are ready"
 
+# The Iceberg JDBC catalog stores its metadata tables in this schema, and the
+# catalog cannot create them itself -- Spark fails with
+#   Cannot initialize JDBC catalog ... no schema has been selected to create in
+# The init-configmap creates it, but Postgres only runs those scripts on a
+# fresh volume, so any cluster deployed before that script existed would never
+# get it. Ensure it here too: CREATE SCHEMA IF NOT EXISTS is idempotent, so
+# this is a no-op on healthy clusters and a repair on older ones.
+info "Ensuring iceberg_catalog schema exists in postgres-dest..."
+kubectl exec -n $NAMESPACE postgres-dest-0 -- bash -c \
+  'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+     -c "CREATE SCHEMA IF NOT EXISTS iceberg_catalog AUTHORIZATION \"$POSTGRES_USER\";"' \
+  >/dev/null 2>&1 && ok "iceberg_catalog schema is ready" \
+  || warn "Could not ensure iceberg_catalog schema — Spark writes to Iceberg will fail until it exists"
+
 # ─── Step 4: MinIO ────────────────────────────────────────────────────────────
 echo ""
 info "Deploying MinIO..."

--- a/k8s/postgres-dest/init-configmap.yaml
+++ b/k8s/postgres-dest/init-configmap.yaml
@@ -45,3 +45,22 @@ data:
     EOSQL
 
     echo "Read-only dashboard role '${DASHBOARD_DB_USER}' is ready."
+  02-create-iceberg-catalog-schema.sh: |
+    #!/bin/bash
+    # Creates the schema that holds Iceberg JDBC catalog metadata
+    # (iceberg_tables / iceberg_namespace_properties), shared by Spark and
+    # Trino. Mirrors docker/postgres-dest-init/02-create-iceberg-catalog-schema.sh
+    # -- that file existed for compose but was never ported here, so on
+    # Kubernetes the schema simply did not exist and every Spark write failed
+    # with "Cannot initialize JDBC catalog ... no schema has been selected to
+    # create in", long after the Spark job itself was working.
+    #
+    # Only runs on a fresh volume; deploy.sh also ensures it on every run so
+    # existing clusters get it without re-initialising the database.
+    set -euo pipefail
+
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+        CREATE SCHEMA IF NOT EXISTS iceberg_catalog AUTHORIZATION ${POSTGRES_USER};
+    EOSQL
+
+    echo "Schema iceberg_catalog is ready."


### PR DESCRIPTION
Root cause of the newest failure in #126. The Spark fixes worked — the job now runs, reads Bronze from MinIO, and fails at the *write*:

```
Cannot initialize JDBC catalog
ERROR: no schema has been selected to create in
```

## Cause

The Iceberg JDBC catalog stores its metadata tables in the schema named by `?currentSchema=iceberg_catalog`, and it cannot create that schema itself.

`docker/postgres-dest-init/` holds two init scripts. Only the first was ever ported to the Kubernetes ConfigMap:

| Script | compose | k8s |
|---|---|---|
| `01-create-dashboard-role.sh` | ✓ | ✓ |
| `02-create-iceberg-catalog-schema.sh` | ✓ | **missing** |

So on Kubernetes the schema never existed, and every Spark write to Iceberg was going to fail regardless of how healthy the cluster was.

It stayed hidden because **nothing ever reached the write step**. Executors were dying on the callback address (#129), then on a version mismatch (#130). Only once both were fixed did the job get far enough to hit this.

## Two changes, because one isn't enough

1. **Add the script to the ConfigMap** — fixes fresh deployments.
2. **Ensure the schema in `deploy.sh` on every run** — Postgres only executes `/docker-entrypoint-initdb.d` on an *empty* data directory, so any cluster deployed before this commit will never pick the script up no matter how many times it redeploys. `CREATE SCHEMA IF NOT EXISTS` is idempotent: a no-op on healthy clusters, a repair on older ones.

Without the second change this PR would fix nothing for the person who reported it.

## Note

Same defect class as the rest of this sequence: a file that exists for compose with no Kubernetes counterpart. `bash -n` clean, yamllint clean, ConfigMap parses with both keys.

Verification of the full path on a real cluster is pending — Docker Desktop's Kubernetes stopped mid-test. The cause here is established by inspection and matches the reported error exactly.