### PR TITLE
fix(spark): bake the Spark JARs into the image instead of fetching per run

### DIFF
--- a/airflow/dags/spark_transform_silver.py
+++ b/airflow/dags/spark_transform_silver.py
@@ -86,6 +86,16 @@ with DAG(
         #
         # The pod IP is routable, so pin to it. bindAddress stays 0.0.0.0 so
         # the driver still listens on all interfaces inside the container.
+        #
+        # --jars, not --conf spark.jars.packages: the JARs are baked into the
+        # image (see docker/airflow/Dockerfile) instead of resolved from Maven
+        # Central on every run. That download was ~1GB per task -- slow, the
+        # thing that filled the node's ephemeral storage before #127, and a
+        # hard failure whenever the cluster cannot reach repo1.maven.org:
+        #   :: UNRESOLVED DEPENDENCIES ::
+        #   module not found: org.apache.iceberg#iceberg-spark-runtime...
+        # Only these two are listed because the Spark workers already ship
+        # hadoop-aws and the AWS SDK; the driver serves these to the executors.
         return f"""
     spark-submit \
         --master {SPARK_MASTER_URL} \
@@ -99,7 +109,7 @@ with DAG(
         --conf spark.hadoop.fs.s3a.secret.key={MINIO_PASSWORD} \
         --conf spark.hadoop.fs.s3a.path.style.access=true \
         --conf spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem \
-        --conf spark.jars.packages=org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.4.2,org.apache.hadoop:hadoop-aws:3.3.4,org.postgresql:postgresql:42.7.4 \
+        --jars /opt/spark-jars/iceberg-spark-runtime-3.5_2.12-1.4.2.jar,/opt/spark-jars/postgresql-42.7.4.jar \
         --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
         --conf spark.sql.catalog.silver=org.apache.iceberg.spark.SparkCatalog \
         --conf spark.sql.catalog.silver.catalog-impl=org.apache.iceberg.jdbc.JdbcCatalog \

--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -12,13 +12,30 @@ USER airflow
 COPY docker/airflow/requirements-airflow.txt /requirements-airflow.txt
 RUN pip install --no-cache-dir -r /requirements-airflow.txt
 
-# Add S3A JARs so spark-submit (run from this container) can access S3/MinIO.
-# PySpark 3.5.0 bundles Hadoop 3.3.4 — versions must match.
+# Bake every JAR the Spark jobs need into the image, at build time.
+#
+# These used to be fetched per run via --conf spark.jars.packages, which meant
+# every single Spark task resolved ~1GB from Maven Central into the pod before
+# doing any work. That is slow, and it fails outright the moment the cluster
+# cannot reach repo1.maven.org:
+#   :: UNRESOLVED DEPENDENCIES ::
+#   module not found: org.apache.iceberg#iceberg-spark-runtime-3.5_2.12;1.4.2
+# It was also what filled the node's ephemeral storage in the incident that
+# led to #127 -- each retained pod was holding its own copy of that download.
+#
+# Baking them in makes runs hermetic: no network at submit time, nothing to
+# re-download, and the versions are pinned in one place instead of a string
+# inside a DAG. PySpark 3.5.0 bundles Hadoop 3.3.4, so hadoop-aws must match
+# it exactly; iceberg-spark-runtime must match Spark 3.5 / Scala 2.12.
 RUN PYSPARK_JARS=$(python -c "import pyspark; import os; print(os.path.join(os.path.dirname(pyspark.__file__), 'jars'))") && \
     curl -fsSL https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar \
         -o "${PYSPARK_JARS}/hadoop-aws-3.3.4.jar" && \
     curl -fsSL https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar \
-        -o "${PYSPARK_JARS}/aws-java-sdk-bundle-1.12.262.jar"
+        -o "${PYSPARK_JARS}/aws-java-sdk-bundle-1.12.262.jar" && \
+    curl -fsSL https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/1.4.2/iceberg-spark-runtime-3.5_2.12-1.4.2.jar \
+        -o "${PYSPARK_JARS}/iceberg-spark-runtime-3.5_2.12-1.4.2.jar" && \
+    curl -fsSL https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.4/postgresql-42.7.4.jar \
+        -o "${PYSPARK_JARS}/postgresql-42.7.4.jar"
 
 # Bake spark jobs into image so they're always available
 # (volume mount ./spark/jobs:/opt/spark-jobs can still override at runtime)
@@ -26,4 +43,17 @@ USER root
 RUN mkdir -p /opt/spark-jobs
 COPY spark/jobs/ /opt/spark-jobs/
 RUN chown -R airflow:root /opt/spark-jobs
+
+# /opt/spark-jars holds the two JARs the EXECUTORS also need. pyspark/jars is
+# already on the driver's classpath, but executors run on the Spark workers,
+# whose image ships hadoop-aws and the AWS SDK and knows nothing about Iceberg
+# or Postgres. Passing these via --jars has the driver serve them to every
+# executor, so the worker image needs no change. A stable path keeps the DAG
+# from having to locate site-packages at runtime. Done here because /opt is
+# only writable as root.
+RUN PYSPARK_JARS=$(su airflow -s /bin/bash -c "python -c \"import pyspark, os; print(os.path.join(os.path.dirname(pyspark.__file__), 'jars'))\"") && \
+    mkdir -p /opt/spark-jars && \
+    cp "${PYSPARK_JARS}/iceberg-spark-runtime-3.5_2.12-1.4.2.jar" \
+       "${PYSPARK_JARS}/postgresql-42.7.4.jar" /opt/spark-jars/ && \
+    chown -R airflow:root /opt/spark-jars
 USER airflow


### PR DESCRIPTION
Latest failure in #126. With the catalog schema fixed, the job got further and died on dependency resolution:

```
:: UNRESOLVED DEPENDENCIES ::
module not found: org.apache.iceberg#iceberg-spark-runtime-3.5_2.12;1.4.2
module not found: org.apache.hadoop#hadoop-aws;3.3.4
module not found: org.postgresql#postgresql;42.7.4
```

Ivy tried the local caches and `repo1.maven.org`, and reached none of them.

## Why this is worth fixing properly rather than retrying

`--conf spark.jars.packages` resolves from Maven Central **on every run**. That is three problems, not one:

- ~1GB downloaded per task before any work happens
- a hard failure whenever the cluster can't reach the internet — this report
- the disk consumption behind the ephemeral-storage evictions in #127, since every retained pod held its own copy

I flagged this as follow-up twice while fixing other things. It has now caused a second incident, so it's no longer worth deferring.

## Change

Bake all four JARs into the Airflow image at build time, and pass the two the executors need via `--jars`. `hadoop-aws` and the AWS SDK are already on the Spark workers, so only `iceberg-spark-runtime` and the Postgres driver need shipping — the driver serves those to each executor, leaving the worker image untouched.

The copy into `/opt/spark-jars` happens in the **root** stage: `/opt` isn't writable as the `airflow` user, and my first attempt failed the build there.

## Verified

Rebuilt the image and ran end to end on compose:

| Check | Result |
|---|---|
| `spark_transform_silver` | **5/5 tasks succeeded** |
| Ivy/Maven resolution lines in log | **0** |
| `iceberg.lake.orders` via Trino | **10000 rows** |

The run finished in about **twenty seconds** rather than minutes — that difference is the download no longer happening.

## Note

Runs are now hermetic at submit time, and the versions are pinned in the Dockerfile rather than in a string inside a DAG. Bump them alongside the `pyspark` pin.