### PR TITLE
fix(build): allow the Spark JARs to be supplied locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ node_modules/
 
 # Local dbt-mcp checkout/venv — vendored copy was removed; never re-commit it
 dbt-mcp/
+# Offline Spark JARs dropped in for restricted networks (see the README there)
+docker/airflow/jars/*.jar

--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -27,15 +27,32 @@ RUN pip install --no-cache-dir -r /requirements-airflow.txt
 # re-download, and the versions are pinned in one place instead of a string
 # inside a DAG. PySpark 3.5.0 bundles Hadoop 3.3.4, so hadoop-aws must match
 # it exactly; iceberg-spark-runtime must match Spark 3.5 / Scala 2.12.
+#
+# Each JAR is taken from docker/airflow/jars/ when a copy is sitting there,
+# and downloaded otherwise. On a normal machine the directory is empty and
+# this behaves exactly as a plain download. On a host that cannot reach
+# repo1.maven.org -- a proxy, an air-gapped network, a firewall that blocks
+# Maven Central -- drop the four files in and the build stops needing the
+# internet at all. See docker/airflow/jars/README.md for the URLs.
+COPY docker/airflow/jars/ /tmp/localjars/
 RUN PYSPARK_JARS=$(python -c "import pyspark; import os; print(os.path.join(os.path.dirname(pyspark.__file__), 'jars'))") && \
-    curl -fsSL https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar \
-        -o "${PYSPARK_JARS}/hadoop-aws-3.3.4.jar" && \
-    curl -fsSL https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar \
-        -o "${PYSPARK_JARS}/aws-java-sdk-bundle-1.12.262.jar" && \
-    curl -fsSL https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/1.4.2/iceberg-spark-runtime-3.5_2.12-1.4.2.jar \
-        -o "${PYSPARK_JARS}/iceberg-spark-runtime-3.5_2.12-1.4.2.jar" && \
-    curl -fsSL https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.4/postgresql-42.7.4.jar \
-        -o "${PYSPARK_JARS}/postgresql-42.7.4.jar"
+    fetch() { \
+        if [ -f "/tmp/localjars/$1" ]; then \
+            echo "using local /tmp/localjars/$1"; \
+            cp "/tmp/localjars/$1" "${PYSPARK_JARS}/$1"; \
+        else \
+            echo "downloading $1"; \
+            curl -fsSL "$2" -o "${PYSPARK_JARS}/$1"; \
+        fi; \
+    } && \
+    fetch hadoop-aws-3.3.4.jar \
+        https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar && \
+    fetch aws-java-sdk-bundle-1.12.262.jar \
+        https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar && \
+    fetch iceberg-spark-runtime-3.5_2.12-1.4.2.jar \
+        https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/1.4.2/iceberg-spark-runtime-3.5_2.12-1.4.2.jar && \
+    fetch postgresql-42.7.4.jar \
+        https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.4/postgresql-42.7.4.jar
 
 # Bake spark jobs into image so they're always available
 # (volume mount ./spark/jobs:/opt/spark-jobs can still override at runtime)

--- a/docker/airflow/jars/README.md
+++ b/docker/airflow/jars/README.md
@@ -1,0 +1,41 @@
+# Offline JARs for the Airflow image
+
+This directory is normally empty. The image build downloads the Spark JARs it
+needs from Maven Central, and that is the usual path.
+
+Put files here only when the build host **cannot reach `repo1.maven.org`** —
+a corporate proxy, an air-gapped network, or a firewall that blocks Maven
+Central. Any file present here is copied into the image instead of being
+downloaded, so the build stops needing the internet.
+
+Partial use is fine: drop in only the ones that fail and the rest are still
+fetched normally.
+
+## Files
+
+Download these on a machine with access, then copy them into this directory:
+
+```
+hadoop-aws-3.3.4.jar
+  https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar
+
+aws-java-sdk-bundle-1.12.262.jar
+  https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar
+
+iceberg-spark-runtime-3.5_2.12-1.4.2.jar
+  https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/1.4.2/iceberg-spark-runtime-3.5_2.12-1.4.2.jar
+
+postgresql-42.7.4.jar
+  https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.4/postgresql-42.7.4.jar
+```
+
+The names must match exactly — the build looks for these filenames.
+
+## Versions
+
+They are not arbitrary. `pyspark` 3.5.0 bundles Hadoop 3.3.4, so `hadoop-aws`
+has to match it, and `iceberg-spark-runtime` has to match Spark 3.5 with Scala
+2.12. If you bump `pyspark` in `requirements-airflow.txt`, these move with it.
+
+The `.jar` files themselves are git-ignored — they are large binaries and do
+not belong in the repository.


### PR DESCRIPTION
The build failure in #126:

```
curl: (22) The requested URL returned error: 429
```

**429 is rate limiting**, not a firewall or DNS — and it is self-inflicted. It is downstream of the driver-host bug fixed in #129: that cluster launched roughly **46,000 executors** over two days, and every Spark submit resolved ~1GB from `repo1.maven.org`. Enough traffic from one address to earn a 429, which then broke both the runtime resolution *and* the build meant to fix it.

(For the record: the "Maven Central does not allow directory browsing" theory is wrong — those URLs are direct file paths, and the same ones worked on that host before.)

## Change

Baking the JARs in (#133) is still correct — it removes the per-run downloads that caused this. But the build itself still needs Maven *once*, and that single request is what is being throttled.

So each JAR is taken from `docker/airflow/jars/` when a copy is present, and downloaded otherwise. The directory ships empty, so **the default path is unchanged** — a normal machine still just downloads. On a host that is rate-limited, proxied, or air-gapped, drop the four files in and the build needs no network at all. Partial use works: only the files present are used locally.

## Verified both paths

```
empty directory:   downloading hadoop-aws-3.3.4.jar            (all four)
populated:         using local /tmp/localjars/hadoop-aws-...   (all four)
```

Built twice to confirm, rather than testing only the branch I changed.

## Notes

- `.jar` files are git-ignored — large binaries don't belong in the repo
- `docker/airflow/jars/README.md` carries the URLs and explains when this is needed
- The 429 should decay on its own; this makes the build independent of that either way