### PR TITLE
fix(monitoring): bound Prometheus disk so it cannot evict the cluster

### DIFF
--- a/k8s/monitoring/prometheus.yaml
+++ b/k8s/monitoring/prometheus.yaml
@@ -63,6 +63,14 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/prometheus
         - --storage.tsdb.retention.time=7d
+        # Time-based retention alone does not bound disk: 7d of samples is
+        # however many bytes 7d happens to produce. On a busy cluster the TSDB
+        # grew until the node hit DiskPressure, the kubelet evicted Prometheus,
+        # the replacement started on a fresh emptyDir and began filling it
+        # again -- dozens of evicted pods, and the api-server and scheduler
+        # taken out alongside it as collateral. A size cap is what actually
+        # bounds it; whichever limit is reached first wins.
+        - --storage.tsdb.retention.size=2GB
         ports:
         - containerPort: 9090
         volumeMounts:
@@ -74,15 +82,29 @@ spec:
           requests:
             memory: "256Mi"
             cpu: "100m"
+            # Declaring ephemeral-storage is what lets the kubelet hold THIS
+            # pod to account. With no request, a pod's usage is compared
+            # against zero, so it always looks over budget and eviction picks
+            # victims essentially at random -- which is how the Airflow
+            # api-server and scheduler died for storage Prometheus was using.
+            ephemeral-storage: "3Gi"
           limits:
             memory: "512Mi"
             cpu: "500m"
+            ephemeral-storage: "4Gi"
       volumes:
       - name: prometheus-config
         configMap:
           name: prometheus-config
       - name: prometheus-data
-        emptyDir: {}   # use a PVC in production for persistence
+        # sizeLimit is the backstop: if the TSDB somehow exceeds it despite
+        # retention.size, the kubelet evicts this pod alone rather than
+        # letting the volume grow until the whole node is under DiskPressure.
+        # Keep it above retention.size so normal operation never trips it.
+        # Use a PVC in production if the metrics history needs to survive a
+        # restart -- an emptyDir starts empty every time the pod moves.
+        emptyDir:
+          sizeLimit: 3Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Reported in #126, a day after the Spark work landed.

**First, the good news in that report:** both DAGs now pass consistently — three successful runs, duration down to **3m27s**. Pipes 1 and 2 are working on that cluster.

But the node hit `DiskPressure` again and took the Airflow api-server, scheduler and dag-processor with it. This time **the Spark pods were not the cause** — the failed list was dozens of evicted Prometheus replicas.

## Cause

Prometheus keeps its TSDB on an `emptyDir` (node ephemeral storage) with only `--storage.tsdb.retention.time=7d`.

**Time-based retention does not bound disk.** Seven days of samples is however many bytes seven days happens to produce. The TSDB grew, the node hit DiskPressure, the kubelet evicted Prometheus, and the replacement started on a *fresh* emptyDir and began filling it again — the same self-reinforcing shape as the Spark incident in #127, in a different resource.

## Three changes, each doing something the others don't

| Change | Why |
|---|---|
| `--storage.tsdb.retention.size=2GB` | Actually bounds the data; whichever retention limit hits first wins |
| `emptyDir.sizeLimit: 3Gi` | Backstop — kubelet evicts *this pod* rather than pressuring the node. Above retention.size so normal operation never trips it |
| `ephemeral-storage` requests/limits | Lets the kubelet hold this pod to account |

That third one explains the collateral damage. With no request, a pod's usage is compared against **zero**, so it always looks over budget and eviction picks victims essentially at random. It's visible in the reporter's own eviction messages:

```
Container api-server was using 65976Ki, request is 0,
has larger consumption of ephemeral-storage
```

The api-server died for storage Prometheus was using.

## Verified on a live cluster

Deployed to a real Kubernetes cluster, not checked by inspection:

```
--storage.tsdb.retention.time=7d
--storage.tsdb.retention.size=2GB
ephemeral-storage request=3Gi  limit=4Gi
emptyDir sizeLimit=3Gi
TSDB started / Server is ready to receive web requests
```

Prometheus accepts the new flag and comes up clean.

## Not addressed

An `emptyDir` still starts empty whenever the pod moves, so metrics history doesn't survive a restart. Whether that history is worth a PVC is a separate decision — the comment in the manifest says so rather than leaving it implied.