### PR TITLE
fix(k8s): stop Spark workers hoarding disk, and charge evictions correctly

### DIFF
--- a/k8s/airflow/helm-values.yaml
+++ b/k8s/airflow/helm-values.yaml
@@ -201,9 +201,16 @@ scheduler:
     requests:
       memory: "1Gi"
       cpu: "500m"
+      # Declared so the kubelet charges disk usage to the pod that caused it.
+      # With no request, usage is compared against zero and every pod looks
+      # over budget, so eviction picks victims at random -- which is how the
+      # scheduler and api-server were repeatedly killed for storage that
+      # Prometheus and the Spark workers were using.
+      ephemeral-storage: "2Gi"
     limits:
       memory: "2Gi"
       cpu: "2"
+      ephemeral-storage: "4Gi"
   startupProbe:
     failureThreshold: 30
     periodSeconds: 10
@@ -226,9 +233,12 @@ apiServer:
     requests:
       memory: "1Gi"
       cpu: "500m"
+      # See the note on scheduler above.
+      ephemeral-storage: "2Gi"
     limits:
       memory: "2Gi"
       cpu: "2"
+      ephemeral-storage: "4Gi"
   # See the note on scheduler above — same 60s default, same consequence.
   startupProbe:
     failureThreshold: 30

--- a/k8s/spark/worker-deployment.yaml
+++ b/k8s/spark/worker-deployment.yaml
@@ -29,6 +29,22 @@ spec:
           value: "no"
         - name: SPARK_RPC_ENCRYPTION_ENABLED
           value: "no"
+        # Delete finished applications' work directories.
+        #
+        # A standalone worker keeps a directory per application it has ever
+        # run -- executor stdout/stderr plus any JARs the driver shipped --
+        # and never removes them on its own. On an hourly pipeline that grows
+        # without limit on node disk, which is how this cluster ended up in
+        # DiskPressure twice. Cleanup is off by default in Spark, so it has to
+        # be asked for.
+        #
+        # Runs every 30 minutes and keeps the last 24 hours, which leaves
+        # recent runs available for debugging while bounding the total.
+        - name: SPARK_WORKER_OPTS
+          value: >-
+            -Dspark.worker.cleanup.enabled=true
+            -Dspark.worker.cleanup.interval=1800
+            -Dspark.worker.cleanup.appDataTtl=86400
         # S3A / MinIO config for workers
         - name: SPARK_EXTRA_CLASSPATH
           value: "/opt/bitnami/spark/jars/hadoop-aws-*.jar:/opt/bitnami/spark/jars/aws-java-sdk-bundle-*.jar"
@@ -43,6 +59,13 @@ spec:
           requests:
             memory: "2Gi"   # increase to 8Gi for 50GB datasets
             cpu: "500m"
+            # Without a request, the kubelet measures this pod's disk usage
+            # against zero, so it always looks over budget and eviction picks
+            # victims at random -- that is how the Airflow api-server and
+            # scheduler were killed for storage other pods were using.
+            # Declaring it makes evictions land on whoever actually overran.
+            ephemeral-storage: "2Gi"
           limits:
             memory: "4Gi"   # increase to 16Gi for 50GB datasets
             cpu: "2"
+            ephemeral-storage: "4Gi"


### PR DESCRIPTION
Found by auditing for the pattern behind #127 and #135, rather than waiting for a third outage.

## 1. Spark worker cleanup was never enabled

A standalone worker keeps a work directory **per application it has ever run** — executor stdout/stderr plus any JARs the driver shipped — and never removes them. Cleanup is off by default in Spark, so it has to be asked for explicitly.

On an hourly pipeline that grows without limit on node disk. The reporter's worker was already holding **148MB**, and that cluster has run thousands of applications. Same shape as both DiskPressure incidents, just slower.

```
-Dspark.worker.cleanup.enabled=true
-Dspark.worker.cleanup.interval=1800     # sweep every 30 min
-Dspark.worker.cleanup.appDataTtl=86400  # keep 24h
```

The TTL keeps recent runs available for debugging while bounding the total.

## 2. Only Prometheus declared `ephemeral-storage`

#135 fixed the pod that was guilty. Everything else still declared nothing, so the *collateral damage* was unfixed. Without a request, the kubelet measures a pod against **zero** — every pod looks over budget and eviction picks victims essentially at random:

```
Container api-server was using 65976Ki, request is 0,
has larger consumption of ephemeral-storage
```

That's why the Airflow control plane kept dying for storage Prometheus and Spark were using.

Added to the Spark workers and the Airflow scheduler and api-server. To be clear about what this does and doesn't do: **it doesn't stop a pod filling the disk** — it makes the eviction land on whoever actually overran instead of a bystander.

## Verified on a live cluster

Spark confirms the setting in its own startup log, rather than me just checking the env var is present:

```
Worker cleanup enabled; old application directories will be deleted in: /opt/bitnami/spark/work
Successfully registered with master
```

and on the running pod:

```
ephemeral-storage  req=2Gi  lim=4Gi
```

## Note

The Airflow values go through the Helm chart, so they take effect on the next `deploy.sh`. `helm` isn't installed locally, so those two blocks are verified as parsed YAML with the correct structure rather than as rendered manifests — the Spark side is verified running.