### PR TITLE
fix(storage): expire Iceberg snapshots and prune Bronze

### DIFF
--- a/airflow/dags/ingest_source_to_bronze.py
+++ b/airflow/dags/ingest_source_to_bronze.py
@@ -297,6 +297,52 @@ def emit_data_quality_metrics(**kwargs):
     _ = kwargs, timezone  # reserved for future per-run labelling
 
 
+def prune_bronze(**kwargs):
+    """Delete Bronze partitions older than BRONZE_RETENTION_DAYS.
+
+    Bronze is a landing area: once a run has been transformed into Silver and
+    the warehouse, the raw extract has served its purpose. Nothing deleted it,
+    so an hourly pipeline wrote parquet into MinIO forever -- on a single-node
+    cluster that storage is the node's disk, and it is one of the things that
+    put the reporting cluster into DiskPressure.
+
+    Set BRONZE_RETENTION_DAYS=0 to disable if you need the full history.
+    """
+    retention_days = int(os.environ.get('BRONZE_RETENTION_DAYS', '7'))
+    if retention_days <= 0:
+        log.info("BRONZE_RETENTION_DAYS=0 — retaining all Bronze data")
+        return
+
+    cutoff = datetime.utcnow() - timedelta(days=retention_days)
+    s3_hook = S3Hook(aws_conn_id='minio_s3')
+    bucket = 'bronze'
+    if not s3_hook.check_for_bucket(bucket):
+        log.info("Bronze bucket does not exist yet — nothing to prune")
+        return
+
+    keys = s3_hook.list_keys(bucket_name=bucket) or []
+    stale = []
+    for key in keys:
+        # Layout: <table>_source/YYYY/MM/DD/part-*.parquet
+        parts = key.split('/')
+        if len(parts) < 4:
+            continue
+        try:
+            written = datetime(int(parts[1]), int(parts[2]), int(parts[3]))
+        except (ValueError, IndexError):
+            continue  # not a dated partition; leave it alone
+        if written < cutoff:
+            stale.append(key)
+
+    if not stale:
+        log.info(f"No Bronze objects older than {retention_days} days")
+        return
+
+    s3_hook.delete_objects(bucket=bucket, keys=stale)
+    log.info(f"Pruned {len(stale)} Bronze objects older than "
+             f"{retention_days} days (before {cutoff:%Y-%m-%d})")
+
+
 with dag:
     # Dynamically generate tasks for each configured table
     ingestion_tasks = []
@@ -330,6 +376,15 @@ with dag:
         python_callable=emit_data_quality_metrics,
     )
 
+    # Drop Bronze partitions past their retention window. Runs after the
+    # Spark trigger so the current extract is never removed before the
+    # lakehouse has had the chance to read it.
+    prune_bronze_task = PythonOperator(
+        task_id="prune_bronze",
+        python_callable=prune_bronze,
+    )
+
     ingestion_tasks >> dbt_transformations
     ingestion_tasks >> trigger_spark
     ingestion_tasks >> data_quality_metrics
+    trigger_spark >> prune_bronze_task

--- a/spark/jobs/iceberg_maintenance.py
+++ b/spark/jobs/iceberg_maintenance.py
@@ -5,6 +5,7 @@ Essential for 1 Billion+ record scalability to prevent the 'Small File Problem'.
 
 import os
 import sys
+from datetime import datetime, timedelta
 from pyspark.sql import SparkSession
 
 
@@ -45,6 +46,34 @@ def run_maintenance(spark, table_name, z_order_col=None):
                 sort_order => 'zorder({z_order_col})'
             )
         """).show()
+
+    # 4. Expire old snapshots — this is the step that actually frees storage.
+    #
+    # Everything above REWRITES data: compaction and Z-ordering write new
+    # files while the previous snapshots still reference the old ones. Iceberg
+    # keeps every snapshot until it is expired, so without this the table only
+    # ever grows, and running maintenance makes it grow FASTER rather than
+    # smaller. A cluster running this pipeline hourly filled its node disk
+    # and started evicting pods.
+    #
+    # Seven days keeps time-travel useful while bounding what is retained.
+    print(f"Expiring snapshots older than 7 days on {table_name}...")
+    spark.sql(f"""
+        CALL silver.system.expire_snapshots(
+            table => '{table_name}',
+            older_than => TIMESTAMP '{
+                (datetime.utcnow() - timedelta(days=7)).strftime('%Y-%m-%d %H:%M:%S')
+            }',
+            retain_last => 5
+        )
+    """).show()
+
+    # 5. Delete files no snapshot references any more. expire_snapshots drops
+    # the metadata pointers; orphans are what compaction left behind when a
+    # write failed partway. Iceberg refuses to look at anything younger than
+    # three days by default, which protects in-flight writes.
+    print(f"Removing orphan files on {table_name}...")
+    spark.sql(f"CALL silver.system.remove_orphan_files(table => '{table_name}')").show()
 
     print(f"--- Maintenance Completed for: {table_name} ---\n")
 


### PR DESCRIPTION
#135 and #136 bounded what the *infrastructure* writes — Prometheus metrics, Spark work dirs. They don't touch what the *pipeline* writes, and that's unbounded in two places. On a single-node cluster the MinIO and Postgres PVCs are the node's disk, so this is the same DiskPressure story from the data side.

## 1. Iceberg snapshots were never expired

`iceberg_maintenance` ran `rewrite_data_files` and `rewrite_manifests`. Both of those **write new files** while the old snapshots still reference the old ones, and Iceberg keeps every snapshot until asked otherwise.

So the table only ever grew — and **running maintenance made it grow faster, not smaller.** Added the two calls that actually release storage:

- `expire_snapshots` — older than 7 days, retain last 5
- `remove_orphan_files` — files left behind by failed writes

## 2. Bronze was never pruned

Every hourly extract writes parquet to `s3a://bronze/<table>_source/YYYY/MM/DD/` and nothing removes it. A fortnight of hourly runs is a fortnight of raw extracts kept forever.

Bronze is a landing area — once a run reaches Silver and the warehouse, the raw copy has done its job. New `prune_bronze` task drops partitions older than `BRONZE_RETENTION_DAYS` (default 7; set `0` to keep everything).

It runs **after** `trigger_spark`, so the current extract is never removed before the lakehouse can read it.

## Verified end to end

```
ingest_source_to_bronze   26/26 tasks succeeded
prune_bronze              Pruned 51 Bronze objects older than 7 days (before 2026-08-07)
```

The task removes real objects, and the DAG stays green with it in the graph.

## What this does and doesn't do

It bounds **future** growth. It does not reclaim what has already accumulated — expiry only takes effect on the next maintenance run, and that job is gated to Sundays 00:00 UTC. A cluster already in DiskPressure needs space freed by hand first; this stops it coming back.