### PR TITLE
fix: reclaim disk automatically instead of asking people to remember

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -296,6 +296,37 @@ kubectl cluster-info
 
 Usually storage: check `kubectl describe pod <pod> -n etl` for PVC events, and confirm the StorageClass you accepted in Step 3 exists (`kubectl get sc`).
 
+### Pods Evicted, or the node reports DiskPressure
+
+```bash
+kubectl describe node | grep DiskPressure
+```
+
+If that says `True`, the node is out of disk and the kubelet is **rejecting** new pods — so you will see dozens of Evicted pods appear within seconds of each other. They were never running; they were turned away on arrival. Nothing schedules until space is freed.
+
+The usual culprit is Docker's build store, not the pipeline. `deploy.sh` rebuilds a 5GB+ Airflow image on every run, and the previous layers plus the BuildKit cache stay behind. The script now prunes what it orphans, but a machine with a backlog from earlier deploys needs one manual pass:
+
+```bash
+docker system prune -a --volumes    # Docker's store: build layers and cache
+sudo crictl rmi --prune             # containerd's store: images Kubernetes runs from
+sudo journalctl --vacuum-size=500M  # systemd journal, often several GB
+```
+
+Those are two separate stores. `crictl` will not touch Docker's, and pruning Docker cannot disturb anything running on the cluster.
+
+Find what is actually holding the space before guessing:
+
+```bash
+df -h /
+sudo du -xh --max-depth=1 / | sort -h | tail -10
+```
+
+Once `DiskPressure` returns to `False`, the rejected pods schedule on their own. This just tidies the list:
+
+```bash
+kubectl delete pod -n etl --field-selector status.phase=Failed
+```
+
 ### A test step fails
 
 ```bash

--- a/airflow/dags/spark_transform_silver.py
+++ b/airflow/dags/spark_transform_silver.py
@@ -144,11 +144,14 @@ with DAG(
     maintenance_task = BashOperator(
         task_id='iceberg_maintenance',
         bash_command=(
-            # Gate on weekday AND hour (%u%H == "700"): with an hourly schedule
-            # the date alone is the same for all 24 Sunday runs, which would
-            # compact 24 times instead of once. -u pins the comparison to UTC
-            # so it cannot drift with container TZ.
-            'if [ "$(date -u -d \'{{ data_interval_end | default(macros.datetime.utcnow()) }}\' +%u%H)" = "700" ]; then '
+            # Gate on the hour only (%H == "00"), so this runs once a day
+            # rather than once an hour. It used to be gated to Sunday as well,
+            # but the job now expires Iceberg snapshots on every run and only
+            # compacts on Sundays -- expiry is what releases disk, and waiting
+            # a week to release disk is how a cluster fills up. The job decides
+            # which mode it is in; this only decides how often it is invoked.
+            # -u pins the comparison to UTC so it cannot drift with container TZ.
+            'if [ "$(date -u -d \'{{ data_interval_end | default(macros.datetime.utcnow()) }}\' +%H)" = "00" ]; then '
             # .strip() matters: the builder's f-string ends with a newline and
             # indent, so without it the "; else" lands on its own line starting
             # with a semicolon -- a bash syntax error that exits 2 before the
@@ -156,7 +159,7 @@ with DAG(
             # as a whole command, where the stray whitespace is harmless, so
             # only this composed one breaks.
             + get_spark_submit_command('Iceberg-Maintenance', '/opt/spark-jobs/iceberg_maintenance.py').strip()
-            + '; else echo "Skipping Iceberg maintenance — runs Sundays at 00:00 only"; fi'
+            + '; else echo "Skipping Iceberg maintenance — runs once daily at 00:00 UTC"; fi'
         ),
         # Run only on Sundays to optimize storage after weekly activity
         execution_timeout=timedelta(hours=2),

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -73,6 +73,25 @@ else
   docker push "$DASHBOARD_IMAGE" || warn "Push failed for dashboard"
   ok "Image pushed: $DASHBOARD_IMAGE"
 
+  # Reclaim what this build just orphaned.
+  #
+  # Both images are rebuilt and re-tagged :latest on every run, so the
+  # previous build's layers become dangling and the BuildKit cache keeps
+  # growing. The Airflow image alone is over 5GB. Nobody thinks to clean up
+  # after a deploy script, so it accumulates silently -- one cluster reached
+  # 20GB in /var/snap/docker over a fortnight of redeploys and hit
+  # DiskPressure, which evicted the Airflow control plane.
+  #
+  # Note this is Docker's store, which is separate from the containerd store
+  # Kubernetes actually runs pods from -- `crictl rmi --prune` does not touch
+  # it, and pruning here cannot disturb anything running on the cluster.
+  #
+  # Only dangling images and stale cache: nothing tagged, nothing in use.
+  info "Reclaiming dangling build layers..."
+  PRUNED=$(docker image prune -f 2>/dev/null | tail -1)
+  docker builder prune -f --filter "until=168h" >/dev/null 2>&1 || true
+  ok "Build cleanup done${PRUNED:+ — $PRUNED}"
+
   # Patch the helm values with actual image in the temporary directory (created later)
   # We'll defer this until TMP_K8S is created.
   export REGISTRY_FOR_REPLACE="$REGISTRY"

--- a/spark/jobs/iceberg_maintenance.py
+++ b/spark/jobs/iceberg_maintenance.py
@@ -18,34 +18,39 @@ def create_spark_session():
         .getOrCreate()
 
 
-def run_maintenance(spark, table_name, z_order_col=None):
+def run_maintenance(spark, table_name, z_order_col=None, compact=True):
     """
-    Performs maintenance tasks on an Iceberg table:
-    1. rewriteDataFiles (Compaction)
-    2. rewriteManifests
-    3. rewriteDataFiles with Z-Ordering (if col provided)
+    Performs maintenance tasks on an Iceberg table.
+
+    Reclaiming storage (expire_snapshots, remove_orphan_files) is cheap and
+    runs every time. Reorganising it (compaction, manifest rewrite,
+    Z-ordering) is expensive and only runs when `compact` is set -- weekly is
+    plenty for layout, but waiting a week to release disk is what let a
+    cluster fill up.
     """
-    print(f"\n--- Starting Maintenance for: {table_name} ---")
-    
-    # 1. Compaction: Merge small files into optimal chunks (default ~128MB)
-    print(f"Running Compaction (rewrite_data_files) on {table_name}...")
-    spark.sql(f"CALL silver.system.rewrite_data_files(table => '{table_name}')").show()
-    
-    # 2. Manifest Optimization: Speed up metadata lookups
-    print(f"Running Manifest Optimization on {table_name}...")
-    spark.sql(f"CALL silver.system.rewrite_manifests(table => '{table_name}')").show()
-    
-    # 3. Z-Ordering: Physically sort data by high-cardinality columns for instant filtering
-    if z_order_col:
-        print(f"Applying Z-Ordering on column '{z_order_col}' for {table_name}...")
-        # Note: Iceberg Spark 3.3+ CALL procedure for Z-ordering
-        spark.sql(f"""
-            CALL silver.system.rewrite_data_files(
-                table => '{table_name}',
-                strategy => 'sort',
-                sort_order => 'zorder({z_order_col})'
-            )
-        """).show()
+    print(f"\n--- Starting Maintenance for: {table_name} "
+          f"({'full' if compact else 'expire-only'}) ---")
+
+    if compact:
+        # 1. Compaction: Merge small files into optimal chunks (default ~128MB)
+        print(f"Running Compaction (rewrite_data_files) on {table_name}...")
+        spark.sql(f"CALL silver.system.rewrite_data_files(table => '{table_name}')").show()
+
+        # 2. Manifest Optimization: Speed up metadata lookups
+        print(f"Running Manifest Optimization on {table_name}...")
+        spark.sql(f"CALL silver.system.rewrite_manifests(table => '{table_name}')").show()
+
+        # 3. Z-Ordering: Physically sort data by high-cardinality columns for instant filtering
+        if z_order_col:
+            print(f"Applying Z-Ordering on column '{z_order_col}' for {table_name}...")
+            # Note: Iceberg Spark 3.3+ CALL procedure for Z-ordering
+            spark.sql(f"""
+                CALL silver.system.rewrite_data_files(
+                    table => '{table_name}',
+                    strategy => 'sort',
+                    sort_order => 'zorder({z_order_col})'
+                )
+            """).show()
 
     # 4. Expire old snapshots — this is the step that actually frees storage.
     #
@@ -79,8 +84,15 @@ def run_maintenance(spark, table_name, z_order_col=None):
 
 
 def main():
+    # Compaction reorganises data; expiry releases it. Doing both weekly
+    # means up to seven days of snapshots accumulate before anything is
+    # freed, which is too slow for an hourly pipeline. Expire every run,
+    # compact on Sundays.
+    compact = datetime.utcnow().isoweekday() == 7
+    print(f"Maintenance mode: {'full (compact + expire)' if compact else 'expire-only'}")
+
     spark = create_spark_session()
-    
+
     # Target our primary analytical tables
     tables_to_optimize = [
         ("silver.lake.orders", "order_date"),
@@ -92,7 +104,7 @@ def main():
     try:
         for table, z_order_col in tables_to_optimize:
             if spark.catalog.tableExists(table):
-                run_maintenance(spark, table, z_order_col)
+                run_maintenance(spark, table, z_order_col, compact=compact)
             else:
                 print(f"Table {table} does not exist yet. Skipping.")
                 


### PR DESCRIPTION
Closes the loop on #126. Raghu suggested a prune in `deploy.sh` — this is that, plus two related things.

## The cause was the build, not the pipeline

His node filled up and evicted the Airflow control plane. 20GB sat in `/var/snap/docker`, because `deploy.sh` rebuilds a 5GB+ Airflow image on every run and nothing removed the layers it orphaned.

`crictl rmi --prune` didn't help because that's **containerd's** store — where Kubernetes runs pods from — not where images are built. Two separate stores; pruning one never touches the other.

## What changed

**1. `deploy.sh` prunes what its own build orphans** — dangling images and BuildKit cache older than a week.

Deliberately **not** `docker system prune -a --volumes`, which Raghu suggested. That also removes base images (`apache/airflow` is ~2GB), so the next deploy re-downloads them. On a host that had *just* been rate-limited by Maven Central, making the build need more network is the wrong trade. Dangling-only reclaims the 5GB per redeploy that actually accumulates, and cannot touch anything tagged or running.

**2. Iceberg maintenance split by cost.** Compaction reorganises data and is expensive; `expire_snapshots` releases it and is cheap. Both ran weekly, so up to seven days of snapshots accumulated before anything was freed — too slow for an hourly pipeline. Expiry now runs daily, compaction stays Sunday. The job picks its own mode from the day of week; the DAG gate moved from Sunday-at-midnight to daily-at-midnight.

**3. The DiskPressure troubleshooting section** he asked for, including the distinction that cost him an evening: dozens of pods Evicted seconds apart are being **rejected** by a full node, not failing. They never ran, and nothing schedules until space is freed.

## Verified

| Check | Result |
|---|---|
| `spark_transform_silver` | 5/5 tasks succeeded |
| `iceberg_maintenance` run directly | `Maintenance mode: expire-only` on a Saturday — no compaction, orphan removal across all four tables, completed |
| `docker builder prune` | 906MB reclaimed, tagged image untouched |
| markdownlint | clean |

I ran the maintenance job directly rather than through the DAG, because the gate reads `data_interval_end` and a manual trigger sets that to *now* — so the DAG path can't exercise the midnight branch on demand. Worth knowing if you test this yourself.