### PR TITLE
fix(airflow): declare ephemeral-storage on dagProcessor and triggerer

### DIFF
--- a/k8s/airflow/helm-values.yaml
+++ b/k8s/airflow/helm-values.yaml
@@ -252,6 +252,39 @@ apiServer:
         targetPort: 8080
         nodePort: 30880
 
+# The dag-processor and triggerer had no resources block at all, so neither
+# declared ephemeral-storage. That is the same gap that got the scheduler and
+# api-server evicted for disk other pods were using -- with no request, the
+# kubelet compares usage against zero and every pod looks over budget, so it
+# picks victims essentially at random.
+#
+# The dag-processor is not a hypothetical here: when a node filled up it was
+# rejected and recreated twenty-five times in six seconds, because the
+# Deployment kept replacing a pod the kubelet would not admit. Both are small
+# and long-lived; these numbers exist to make evictions land on whoever
+# actually overran, not to constrain them.
+dagProcessor:
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+      ephemeral-storage: "1Gi"
+    limits:
+      memory: "1Gi"
+      cpu: "1"
+      ephemeral-storage: "2Gi"
+
+triggerer:
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+      ephemeral-storage: "1Gi"
+    limits:
+      memory: "1Gi"
+      cpu: "1"
+      ephemeral-storage: "2Gi"
+
 webserverSecretKey: "etl-secret-key-change-in-production"
 
 # The chart deploys a statsd-exporter (airflow-statsd) that Prometheus scrapes


### PR DESCRIPTION
Finishes what #136 started.

That PR gave the scheduler and api-server an `ephemeral-storage` request so the kubelet would charge disk usage to whoever actually overran. It **missed the dag-processor and triggerer**, which had no `resources` block at all — so those two are still measured against zero, still always look over budget, and are still picked as eviction victims for storage other pods are using.

## The dag-processor is not hypothetical here

When the reporting node filled up, it was rejected and recreated **twenty-five times inside six seconds** — the Deployment kept replacing a pod the kubelet would not admit:

```
airflow-dag-processor-...-2rzfd   Evicted   2m38s
airflow-dag-processor-...-tmwzp   Evicted   2m32s
```

It was the single most affected pod in that incident, and the only one left without a declaration.

## Values

Both are small and long-lived, so the numbers are modest — 1Gi request, 2Gi limit. They exist to make evictions land correctly, not to constrain these components.

| Component | request | limit |
|---|---|---|
| scheduler | 2Gi | 4Gi |
| apiServer | 2Gi | 4Gi |
| **dagProcessor** | **1Gi** | **2Gi** |
| **triggerer** | **1Gi** | **2Gi** |

## Verified

`helm` isn't installed here, so rather than assume the key names I checked them against the apache-airflow chart itself — both `dagProcessor` and `triggerer` expose a `resources` block. yamllint clean, and all four components parse with the expected values.