### PR TITLE
fix(airflow): stop #140 reserving memory and cpu it did not need

### DIFF
--- a/k8s/airflow/helm-values.yaml
+++ b/k8s/airflow/helm-values.yaml
@@ -260,29 +260,26 @@ apiServer:
 #
 # The dag-processor is not a hypothetical here: when a node filled up it was
 # rejected and recreated twenty-five times in six seconds, because the
-# Deployment kept replacing a pod the kubelet would not admit. Both are small
-# and long-lived; these numbers exist to make evictions land on whoever
-# actually overran, not to constrain them.
+# Deployment kept replacing a pod the kubelet would not admit.
+#
+# ONLY ephemeral-storage is declared, deliberately. The first version of this
+# also set memory and cpu requests, which reserved 1Gi and 500m that these
+# two never previously held -- and on a busy node that is enough to leave
+# nothing for the next pod to schedule. kafka-connect went Pending straight
+# after. Eviction accounting needs the storage figure; it does not need the
+# other two, so they are gone.
 dagProcessor:
   resources:
     requests:
-      memory: "512Mi"
-      cpu: "250m"
       ephemeral-storage: "1Gi"
     limits:
-      memory: "1Gi"
-      cpu: "1"
       ephemeral-storage: "2Gi"
 
 triggerer:
   resources:
     requests:
-      memory: "512Mi"
-      cpu: "250m"
       ephemeral-storage: "1Gi"
     limits:
-      memory: "1Gi"
-      cpu: "1"
       ephemeral-storage: "2Gi"
 
 webserverSecretKey: "etl-secret-key-change-in-production"


### PR DESCRIPTION
Fixes #141. **This is a regression I introduced.**

`kafka-connect` went `Pending` and `deploy.sh` timed out waiting for it — immediately after pulling the commit containing #140.

## What #140 got wrong

It set out to declare `ephemeral-storage` on the dag-processor and triggerer so evictions would be charged to the right pod. But it gave both a *full* resources block — **512Mi memory and 250m CPU each**, which neither had requested before.

That's **1Gi of memory and 500m of CPU newly reserved** on a node already running the whole stack. `kafka-connect` needs 512Mi and 250m to schedule. Reserving capacity it then has to compete for is a plausible way to make it Pending, and the timing lines up exactly.

## The fix

Those requests were never the point. Eviction accounting needs the storage figure and nothing else:

```yaml
dagProcessor:
  resources:
    requests:
      ephemeral-storage: "1Gi"
    limits:
      ephemeral-storage: "2Gi"
```

Both components go back to being unconstrained on memory and CPU, as they were before #140, while keeping the storage declaration #140 was actually for.

## Why I looked at my own change first

`kafka-connect` has no PVC, no `nodeSelector`, no affinity and no tolerations — nothing in its own definition explains `Pending`. When a pod with no scheduling constraints suddenly can't be placed, the cause is what changed around it, and what changed around it was mine.

## Confirming

`kubectl describe pod kafka-connect-0 -n etl` will name the exact resource in its Events. I've asked for it on the issue — if it says something other than insufficient memory or CPU, this PR is still correct on its own merits but won't be the whole story.