### PR TITLE
docs: explain why Iceberg compaction does not reclaim space

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,47 @@ make seed                # Generate sample source data
 make register-connector  # Initialize Debezium CDC connector
 ```
 
+## Storage Growth
+
+Every layer here writes continuously, and most of it is bounded by something
+that has to be asked for rather than assumed. The non-obvious one is Iceberg.
+
+### Compaction does not reclaim space — expiry does
+
+Iceberg is copy-on-write. `rewrite_data_files` (compaction) merges small files
+into larger ones by **writing new files**; the old ones stay, because earlier
+snapshots still reference them. Iceberg keeps every snapshot until told
+otherwise, so compaction on its own *increases* storage. Running maintenance
+more often makes the problem worse, not better.
+
+Two procedures actually release space, and both are in
+`spark/jobs/iceberg_maintenance.py`:
+
+| Procedure | What it does |
+|---|---|
+| `expire_snapshots` | Drops snapshots past the retention window, so the files they held become unreferenced |
+| `remove_orphan_files` | Deletes files no snapshot references — typically left by a write that failed partway |
+
+Because expiry is cheap and compaction is expensive, they run on different
+cadences: **expiry every day, compaction on Sundays**. The job picks its mode
+from the day of the week; the DAG only decides how often it is invoked.
+Waiting a week to release disk is enough to fill a modest node.
+
+### What else is bounded, and where
+
+| Data | Bound | Set in |
+|---|---|---|
+| Bronze parquet | 7 days, `BRONZE_RETENTION_DAYS` | `prune_bronze` task in the ingest DAG |
+| Iceberg snapshots | 7 days, keep last 5 | `iceberg_maintenance.py` |
+| Prometheus TSDB | 2GB, whichever of size/time hits first | `k8s/monitoring/prometheus.yaml` |
+| Spark worker dirs | 24h TTL, swept every 30 min | `SPARK_WORKER_OPTS` in the worker manifest |
+| Docker build layers | pruned after each build | `k8s/deploy.sh` |
+
+On a single-node cluster the PersistentVolumes are the node's disk, so any of
+these growing without limit eventually stops pods being scheduled at all —
+see the DiskPressure section in [DEPLOY_GUIDE.md](DEPLOY_GUIDE.md) for what
+that looks like and how to recover.
+
 ## Security Notes
 
 - The AI dashboard executes only single read-only SELECT statements, over a SELECT-only database role, behind optional HTTP Basic Auth.


### PR DESCRIPTION
Raghu asked for this in #126 — the compaction-vs-expiry distinction is worth capturing for the docs and the paper. He's right, and working it out cost an incident: a node filled up, evicted the Airflow control plane, and the maintenance job meant to help had been making it worse.

## The point

Iceberg is copy-on-write. `rewrite_data_files` merges small files by **writing new ones** — the old files stay, because earlier snapshots still reference them, and Iceberg keeps every snapshot until told otherwise.

So compaction alone *increases* storage, and running it more often increases it faster. `expire_snapshots` and `remove_orphan_files` are what actually release space.

That isn't obvious from the names — "compaction" sounds like it compacts — and until now it lived only in a PR description and a code comment, which is not where the next person looks.

## Also documented

The other five bounds and where each is configured:

| Data | Bound | Set in |
|---|---|---|
| Bronze parquet | 7 days | `prune_bronze` task |
| Iceberg snapshots | 7 days, keep last 5 | `iceberg_maintenance.py` |
| Prometheus TSDB | 2GB | `k8s/monitoring/prometheus.yaml` |
| Spark worker dirs | 24h TTL | `SPARK_WORKER_OPTS` |
| Docker build layers | each build | `k8s/deploy.sh` |

Plus the thing that makes it bite: on a single-node cluster the PVCs *are* the node's disk, so any of these growing unchecked eventually stops pods being scheduled at all — cross-referenced to the DiskPressure section in the deploy guide.

## Verified

Every figure cross-checked against the committed code rather than written from memory — retention windows, `retain_last => 5`, the daily/weekly split (`+%H = 00` in the DAG, `isoweekday() == 7` in the job), and the `deploy.sh` prune all match. markdownlint clean.

Documentation that quietly drifts from the code is worse than none, so the numbers are quoted from the files that set them.