### PR TITLE
Spark driver-host on real Kubernetes, disk-eviction root cause, and the fixes it surfaced

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -294,7 +294,43 @@ kubectl cluster-info
 
 ### Pods stuck in Pending
 
-Usually storage: check `kubectl describe pod <pod> -n etl` for PVC events, and confirm the StorageClass you accepted in Step 3 exists (`kubectl get sc`).
+Read the `Events` line of `kubectl describe pod <pod> -n etl` and note *which* reason it gives — they need opposite fixes and look identical at a glance.
+
+`Insufficient cpu` or `Insufficient memory` is a capacity problem: something requested more than the node has left.
+
+A **taint** is not. This is the one to recognise:
+
+```text
+0/2 nodes are available:
+  1 node(s) had untolerated taint {node-role.kubernetes.io/control-plane: }
+  1 node(s) had untolerated taint {node.kubernetes.io/disk-pressure: }
+```
+
+The control-plane taint is normal and permanent. `node.kubernetes.io/disk-pressure` is the kubelet reporting that the node's root filesystem has crossed its eviction threshold (10–15% free depending on distribution). It taints the node `NoSchedule` and starts evicting pods, so *nothing* new schedules regardless of what it requests. Adjusting resource requests will not help.
+
+Check the node itself — and mind that these commands are node-local, so run them on the node that is actually complaining, not the control-plane:
+
+```bash
+kubectl describe node <node> | grep -A8 Conditions
+ssh <node> df -h /
+ssh <node> "sudo du -xh --max-depth=1 / 2>/dev/null | sort -h | tail -12"
+```
+
+The alerts in `NodeDiskFillingUp` / `NodeDiskNearEvictionThreshold` are meant to catch this days earlier. If they never fired, confirm node-exporter is reading the host filesystem rather than its own container — it needs `--path.rootfs=/host` and a read-only `/` mount, both of which the manifests set.
+
+### PVC sizes are not limits on a local StorageClass
+
+`local-path` (and `hostPath`) hand out a plain directory on the node. The `storage:` figure in a PVC is a label with no mechanism behind it: no quota, no device, no separate filesystem. A pod can write past its request until the **node's** disk is full, and every byte counts against the same filesystem the kubelet watches for eviction.
+
+The default manifests claim roughly 300Gi in total. On a single 100G node every claim still binds and the cluster reports itself healthy — right up until one workload grows into the space and takes the node down with it. On one cluster ClickHouse reached 34G against a 20Gi claim and evicted the Airflow control plane.
+
+If your nodes are smaller than the sum of the claims, either point the StorageClass at real volumes, or lower the requests **before first deploy**. Lowering them afterwards is not a live change: `volumeClaimTemplates` are immutable, so `kubectl apply` and `helm upgrade` both reject it. Changing one means deleting the StatefulSet with `--cascade=orphan`, editing, and re-applying — plan it, do not discover it mid-incident.
+
+Watch the actual consumption rather than the claims:
+
+```bash
+ssh <node> "sudo du -xh --max-depth=2 /opt/local-path-provisioner | sort -h | tail"
+```
 
 ### A test step fails
 

--- a/README.md
+++ b/README.md
@@ -132,8 +132,7 @@ order by revenue desc;
 | **Row Warehouse / Mirror** | PostgreSQL 15 |
 | **Columnar Mirror** | ClickHouse 25.3 |
 | **AI Assistant** | Next.js + Claude (agentic SQL over all stores) |
-| **BI / Dashboards** | Metabase |
-| **Monitoring** | Prometheus & Grafana |
+| **Monitoring & alerting** | Prometheus, Grafana & Alertmanager |
 
 ## Quick Start
 
@@ -158,12 +157,11 @@ Kubernetes: `bash k8s/generate-secrets.sh && bash k8s/deploy.sh` (see [DEPLOY_GU
 | Service | Local URL | Credentials (from `.env`) |
 |---|---|---|
 | **Airflow UI** | <http://localhost:8080> | admin / admin |
-| **AI Dashboard** | <http://localhost:3001> *(run `npm run dev -- -p 3001` in `ui/`; 3000 is Grafana's)* | open unless `DASHBOARD_AUTH_PASSWORD` set |
+| **AI Dashboard** | <http://localhost:3001> *(started by `make up`; 3000 is Grafana's)* | open unless `DASHBOARD_AUTH_PASSWORD` set |
 | **Trino UI** | <http://localhost:8082> | any username |
 | **ClickHouse** | <http://localhost:8123> | `CLICKHOUSE_USER` / `CLICKHOUSE_PASSWORD` |
 | **MinIO Console** | <http://localhost:9001> | `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` |
 | **Kafka UI** | <http://localhost:8001> | `KAFKA_UI_USER` / `KAFKA_UI_PASSWORD` |
-| **Metabase** | <http://localhost:3030> | (setup required) |
 | **Spark Master** | <http://localhost:8081> | — |
 | **Grafana** | <http://localhost:3000> *(compose)* | `GRAFANA_ADMIN_USER` / password |
 

--- a/airflow/dags/config/pipelines.yml
+++ b/airflow/dags/config/pipelines.yml
@@ -21,6 +21,7 @@ tables:
   customers:
     primary_key: customer_id
     cursor_column: updated_at        # incremental extract high-water mark
+    partition_column: created_at     # immutable — see note at the bottom
     columns:
       customer_id: BIGINT
       first_name: TEXT
@@ -38,6 +39,7 @@ tables:
   products:
     primary_key: product_id
     cursor_column: updated_at
+    partition_column: created_at     # immutable — see note at the bottom
     columns:
       product_id: BIGINT
       name: TEXT
@@ -53,6 +55,7 @@ tables:
   orders:
     primary_key: order_id
     cursor_column: updated_at
+    partition_column: created_at     # immutable — see note at the bottom
     columns:
       order_id: BIGINT
       customer_id: BIGINT
@@ -67,6 +70,7 @@ tables:
   order_items:
     primary_key: item_id
     cursor_column: updated_at
+    partition_column: created_at     # immutable — see note at the bottom
     columns:
       item_id: BIGINT
       order_id: BIGINT
@@ -76,3 +80,29 @@ tables:
       created_at: TIMESTAMP
       updated_at: TIMESTAMP
     update_columns: [quantity, unit_price, updated_at]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# partition_column
+#
+# Sets `PARTITION BY toYYYYMM(<col>)` on the ClickHouse mirror table. It must
+# name a column the source never UPDATEs — which is why it is created_at and
+# not updated_at, and why it must never appear in update_columns above.
+#
+# The mirror tables are ReplacingMergeTree: every CDC event appends a row, and
+# the superseded versions of a key are only discarded when the parts holding
+# them are merged. Merges happen within a partition, and ClickHouse will not
+# start a merge it lacks the free disk to finish. Unpartitioned, the table is
+# one ever-growing part set, so on a tight disk the merge that would reclaim
+# space is the first thing skipped -- and the table then grows faster than
+# before. One cluster reached 34G against a 20Gi claim this way.
+#
+# Partition on a mutable column and it fails differently and worse: versions of
+# one row land in different partitions, no merge can ever bring them together,
+# and <t>_current returns a row per partition the key has visited. load_manifest
+# rejects that outright rather than let it ship.
+#
+# Not set: no TTL. These tables mirror current state, so an age-based TTL would
+# delete rows that are still live in the source -- a customer who has not been
+# touched in 90 days is still a customer. If a table ever becomes a genuine
+# rolling window, add the TTL deliberately for that table, not as a default.
+# ─────────────────────────────────────────────────────────────────────────────

--- a/airflow/dags/pipeline_config.py
+++ b/airflow/dags/pipeline_config.py
@@ -51,7 +51,44 @@ def load_manifest(path=None):
             missing = [c for c in table.get(key, []) if c not in table['columns']]
             if missing:
                 raise ValueError(f"{name}: {key} not in columns: {missing}")
+        _validate_partition(name, table)
     return manifest
+
+
+def _validate_partition(name, table):
+    """A ReplacingMergeTree only collapses duplicates within one partition.
+
+    Every CDC event appends a row, and the versions of a key are only reduced
+    to one when the parts holding them are merged -- which happens per
+    partition. Partition on a column the source can UPDATE and the versions of
+    a single key land in different partitions, where no merge will ever bring
+    them together. They stop being duplicates ClickHouse can collapse and
+    become permanent copies, and `FINAL` will not save you either: it dedupes
+    per partition too, so `<t>_current` starts returning one row per partition
+    the key ever visited.
+
+    That failure is silent and unbounded, so the column is checked here rather
+    than left to whoever edits the manifest next.
+    """
+    col = table.get('partition_column')
+    if col is None:
+        return
+    if col not in table['columns']:
+        raise ValueError(f"{name}: partition_column {col} not in columns")
+    base = table['columns'][col].upper()
+    if not (base.startswith('TIMESTAMP') or base.startswith('DATE')):
+        raise ValueError(
+            f"{name}: partition_column {col} is {table['columns'][col]}; "
+            f"partitioning is by month, so it must be TIMESTAMP or DATE"
+        )
+    if col in table.get('update_columns', []):
+        raise ValueError(
+            f"{name}: partition_column {col} is also in update_columns. "
+            f"A mutable partition key scatters the versions of one row across "
+            f"partitions, where ReplacingMergeTree can never collapse them and "
+            f"{name}_current returns duplicates. Partition on a column the "
+            f"source never updates (created_at), not one it does."
+        )
 
 
 def topics(manifest):

--- a/airflow/dags/spark_transform_silver.py
+++ b/airflow/dags/spark_transform_silver.py
@@ -66,6 +66,25 @@ with DAG(
     # is passed (see transform_orders.py), so this only makes the DAG agree
     # with the jobs it calls.
 
+    # Secrets are passed to the task's environment, never interpolated into the
+    # command string. Airflow stores every bash_command it renders and shows it
+    # under "Rendered Template" in the UI, so a password written into the
+    # command is a password in the metadata database, in the task log, and on
+    # any screen showing that page. Referencing $MINIO_ROOT_PASSWORD instead
+    # keeps the literal name in all three places and lets the shell substitute
+    # the value at exec time.
+    #
+    # This does not hide the value from `ps` inside the task container -- Spark
+    # takes these as --conf arguments, so they land in the process's argv
+    # either way. Closing that too means a Spark properties file mounted from a
+    # secret, which is a larger change than this one.
+    SPARK_SECRET_ENV = {
+        'MINIO_ROOT_USER': MINIO_USER,
+        'MINIO_ROOT_PASSWORD': MINIO_PASSWORD,
+        'DEST_DB_USER': DEST_DB_USER,
+        'DEST_DB_PASSWORD': DEST_DB_PASSWORD,
+    }
+
     # Helper function to generate standardized spark-submit commands
     def get_spark_submit_command(job_name, script_path, additional_args=""):
         # spark.driver.host: advertise the driver's IP, not its hostname.
@@ -95,8 +114,8 @@ with DAG(
         --conf spark.executor.cores=2 \
         --conf spark.sql.adaptive.enabled=true \
         --conf spark.hadoop.fs.s3a.endpoint={MINIO_ENDPOINT} \
-        --conf spark.hadoop.fs.s3a.access.key={MINIO_USER} \
-        --conf spark.hadoop.fs.s3a.secret.key={MINIO_PASSWORD} \
+        --conf spark.hadoop.fs.s3a.access.key=$MINIO_ROOT_USER \
+        --conf spark.hadoop.fs.s3a.secret.key=$MINIO_ROOT_PASSWORD \
         --conf spark.hadoop.fs.s3a.path.style.access=true \
         --conf spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem \
         --conf spark.jars.packages=org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.4.2,org.apache.hadoop:hadoop-aws:3.3.4,org.postgresql:postgresql:42.7.4 \
@@ -104,8 +123,8 @@ with DAG(
         --conf spark.sql.catalog.silver=org.apache.iceberg.spark.SparkCatalog \
         --conf spark.sql.catalog.silver.catalog-impl=org.apache.iceberg.jdbc.JdbcCatalog \
         --conf spark.sql.catalog.silver.uri={ICEBERG_CATALOG_URI} \
-        --conf spark.sql.catalog.silver.jdbc.user={DEST_DB_USER} \
-        --conf spark.sql.catalog.silver.jdbc.password={DEST_DB_PASSWORD} \
+        --conf spark.sql.catalog.silver.jdbc.user=$DEST_DB_USER \
+        --conf spark.sql.catalog.silver.jdbc.password=$DEST_DB_PASSWORD \
         --conf spark.sql.catalog.silver.warehouse=s3a://silver/ \
         --name {job_name} {script_path} {additional_args}
     """
@@ -113,21 +132,29 @@ with DAG(
     transform_orders = BashOperator(
         task_id='transform_orders',
         bash_command=get_spark_submit_command('Orders-Bronze-to-Silver', '/opt/spark-jobs/transform_orders.py', '{{ (data_interval_end | default(macros.datetime.utcnow())).strftime("%Y%m%d") }}'),
+        env=SPARK_SECRET_ENV,
+        append_env=True,
     )
 
     transform_customers = BashOperator(
         task_id='transform_customers',
         bash_command=get_spark_submit_command('Customers-Bronze-to-Silver', '/opt/spark-jobs/transform_customers.py', '{{ (data_interval_end | default(macros.datetime.utcnow())).strftime("%Y%m%d") }}'),
+        env=SPARK_SECRET_ENV,
+        append_env=True,
     )
 
     transform_products = BashOperator(
         task_id='transform_products',
         bash_command=get_spark_submit_command('Products-Bronze-to-Silver', '/opt/spark-jobs/transform_products.py', '{{ (data_interval_end | default(macros.datetime.utcnow())).strftime("%Y%m%d") }}'),
+        env=SPARK_SECRET_ENV,
+        append_env=True,
     )
 
     transform_order_items = BashOperator(
         task_id='transform_order_items',
         bash_command=get_spark_submit_command('OrderItems-Bronze-to-Silver', '/opt/spark-jobs/transform_order_items.py', '{{ (data_interval_end | default(macros.datetime.utcnow())).strftime("%Y%m%d") }}'),
+        env=SPARK_SECRET_ENV,
+        append_env=True,
     )
 
     # Weekly Maintenance: Compaction & Z-Ordering (Essential for 1 Billion+ records)
@@ -148,6 +175,8 @@ with DAG(
             + get_spark_submit_command('Iceberg-Maintenance', '/opt/spark-jobs/iceberg_maintenance.py').strip()
             + '; else echo "Skipping Iceberg maintenance — runs Sundays at 00:00 only"; fi'
         ),
+        env=SPARK_SECRET_ENV,
+        append_env=True,
         # Run only on Sundays to optimize storage after weekly activity
         execution_timeout=timedelta(hours=2),
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -271,6 +271,10 @@ services:
       # Single file, not the directory: mounting the directory would mask the
       # image's docker_related_config.xml and the server would bind loopback only
       - ./docker/clickhouse/config.d/kafka.xml:/etc/clickhouse-server/config.d/kafka.xml:ro
+      # Bounds ClickHouse's own internal logging (trace_log, metric_log, ...).
+      # Unbounded, these grew to 34G on one node and took it past the
+      # kubelet's eviction threshold -- see #144.
+      - ./docker/clickhouse/config.d/02_system_log_retention.xml:/etc/clickhouse-server/config.d/02_system_log_retention.xml:ro
     networks:
       - etl-network
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -342,6 +342,16 @@ services:
   node-exporter:
     image: prom/node-exporter:latest
     container_name: node-exporter
+    command:
+      # Without --path.rootfs and the mount below, node_filesystem_* reports
+      # this container's filesystem rather than the host's, so the disk alerts
+      # in monitoring/alert_rules.yml would watch the wrong device and never
+      # fire as the real one filled.
+      - '--path.rootfs=/host'
+      - '--collector.filesystem.mount-points-exclude=^/host/(dev|proc|sys|run)($$|/)'
+    pid: host
+    volumes:
+      - /:/host:ro,rslave
     ports:
       - "9100:9100"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -508,16 +508,43 @@ services:
     command: dag-processor
     networks:
       - etl-network
-  # Metabase Business Intelligence
-  metabase:
-    image: metabase/metabase:latest
-    container_name: metabase
+  # AI Data Dashboard (Next.js) — the same image k8s/ui/deployment.yaml runs
+  data-dashboard:
+    build:
+      context: ./ui
+      dockerfile: Dockerfile
+    image: data-dashboard:latest
+    container_name: data-dashboard
+    depends_on:
+      postgres-dest:
+        condition: service_healthy
+    environment:
+      DEST_DB_HOST: postgres-dest
+      DEST_DB_PORT: 5432
+      DEST_DB_NAME: ${DEST_DB_NAME:-destdb}
+      # Read-only warehouse role — the dashboard never needs write access
+      DEST_DB_USER: ${DASHBOARD_DB_USER:-dashboard_ro}
+      DEST_DB_PASSWORD: ${DASHBOARD_DB_PASSWORD:-dashboard_ro}
+      TRINO_URL: http://trino:8080
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-chuser}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-chpass}
+      # Set both to require a login. Left unset the dashboard is open, which
+      # is fine on a laptop and not on anything shared.
+      DASHBOARD_AUTH_USER: ${DASHBOARD_AUTH_USER:-}
+      DASHBOARD_AUTH_PASSWORD: ${DASHBOARD_AUTH_PASSWORD:-}
+      # Optional: without it the assistant runs in demo mode.
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
     ports:
-      - "3030:3000"
-    volumes:
-      - metabase-data:/metabase-data
+      # 3000 inside the container; 3001 on the host because Grafana owns 3000
+      - "3001:3000"
     networks:
       - etl-network
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost:3000/"]
+      interval: 30s
+      retries: 5
+      start_period: 20s
 
   # StatsD Exporter for Airflow Metrics
   statsd-exporter:
@@ -535,7 +562,6 @@ services:
 
 volumes:
   clickhouse-data:
-  metabase-data:
   postgres-source-data:
   postgres-dest-data:
   kafka-data:

--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:3.3.0-python3.11
+FROM apache/airflow:3.3.1-python3.11
 
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends openjdk-17-jdk-headless \

--- a/docker/airflow/requirements-airflow.txt
+++ b/docker/airflow/requirements-airflow.txt
@@ -1,4 +1,8 @@
-apache-airflow==3.3.0
+apache-airflow==3.3.1
+# Not a direct dependency -- dbt-core pulls it in for SQL parsing. See the
+# matching comment in requirements.txt for why this is floored explicitly
+# rather than left to the resolver.
+sqlparse>=0.6.0
 pandas>=2.1.4
 psycopg2-binary>=2.9.9
 pyarrow>=14.0.1

--- a/docker/clickhouse/config.d/02_system_log_retention.xml
+++ b/docker/clickhouse/config.d/02_system_log_retention.xml
@@ -1,0 +1,121 @@
+<clickhouse>
+    <!--
+      ClickHouse's own internal logging, not our data, and by default every
+      one of these is on, unbounded, and partitioned by month, which is
+      exactly the trap #144 hit in the mirror tables before this repo
+      partitioned them: nothing expires, and a partition that only rolls
+      monthly waits weeks before ALTER ... DROP PARTITION has anything to
+      drop.
+
+      trace_log samples a stack trace roughly once a second per running
+      query, and every Kafka Engine table in mirror/01_mirror_schema.sql
+      polls continuously, so it is effectively always "running a query".
+      metric_log snapshots the whole system.metrics/system.events set once a
+      second, unconditionally, whether or not anything is happening.
+      Nineteen days of both, uncapped, was 34G on one node: point for point
+      where #144's TRUNCATE landed, at 13.2s and 11.9s respectively versus
+      under a tenth of a second for every other system table cleared in the
+      same session.
+
+      Daily partitions plus a short TTL bound it going forward. This does not
+      touch anything under `mirror`: Kafka Engine, materialized views, and
+      the ReplacingMergeTree tables they feed are untouched.
+
+      Not every table below is guaranteed to exist in every ClickHouse
+      version: system.query_thread_log, for one, was folded into
+      system.query_log some releases back. A config block for a table this
+      build does not have is inert, not an error, so this stays exhaustive
+      rather than probing each cluster's exact version first.
+    -->
+
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <partition_by>toYYYYMMDD(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </query_log>
+
+    <query_thread_log>
+        <database>system</database>
+        <table>query_thread_log</table>
+        <partition_by>toYYYYMMDD(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </query_thread_log>
+
+    <query_views_log>
+        <database>system</database>
+        <table>query_views_log</table>
+        <partition_by>toYYYYMMDD(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </query_views_log>
+
+    <part_log>
+        <database>system</database>
+        <table>part_log</table>
+        <partition_by>toYYYYMMDD(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </part_log>
+
+    <!-- The two confirmed by #144: 29G and 5.2G of the 34G that took the
+         node down, at roughly matching truncate times. Short TTL, and daily
+         partitions so that TTL has something cheap to drop. -->
+    <trace_log>
+        <database>system</database>
+        <table>trace_log</table>
+        <partition_by>toYYYYMMDD(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 3 DAY DELETE</ttl>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </trace_log>
+
+    <metric_log>
+        <database>system</database>
+        <table>metric_log</table>
+        <partition_by>toYYYYMMDD(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 3 DAY DELETE</ttl>
+        <collect_interval_milliseconds>1000</collect_interval_milliseconds>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </metric_log>
+
+    <asynchronous_metric_log>
+        <database>system</database>
+        <table>asynchronous_metric_log</table>
+        <partition_by>toYYYYMMDD(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 3 DAY DELETE</ttl>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </asynchronous_metric_log>
+
+    <session_log>
+        <database>system</database>
+        <table>session_log</table>
+        <partition_by>toYYYYMMDD(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </session_log>
+
+    <text_log>
+        <database>system</database>
+        <table>text_log</table>
+        <partition_by>toYYYYMMDD(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 3 DAY DELETE</ttl>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </text_log>
+
+    <crash_log>
+        <database>system</database>
+        <table>crash_log</table>
+        <partition_by>toYYYYMMDD(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+    </crash_log>
+
+    <processors_profile_log>
+        <database>system</database>
+        <table>processors_profile_log</table>
+        <partition_by>toYYYYMMDD(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 3 DAY DELETE</ttl>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </processors_profile_log>
+</clickhouse>

--- a/docker/clickhouse/initdb/01_mirror_schema.sql
+++ b/docker/clickhouse/initdb/01_mirror_schema.sql
@@ -31,6 +31,7 @@ CREATE TABLE IF NOT EXISTS mirror.customers
     is_deleted  UInt8
 )
 ENGINE = ReplacingMergeTree(ver, is_deleted)
+PARTITION BY toYYYYMM(created_at)
 ORDER BY customer_id;
 
 -- The consumer and its view carry no data, so they are rebuilt every time this
@@ -87,6 +88,7 @@ CREATE TABLE IF NOT EXISTS mirror.products
     is_deleted     UInt8
 )
 ENGINE = ReplacingMergeTree(ver, is_deleted)
+PARTITION BY toYYYYMM(created_at)
 ORDER BY product_id;
 
 -- The consumer and its view carry no data, so they are rebuilt every time this
@@ -140,6 +142,7 @@ CREATE TABLE IF NOT EXISTS mirror.orders
     is_deleted   UInt8
 )
 ENGINE = ReplacingMergeTree(ver, is_deleted)
+PARTITION BY toYYYYMM(created_at)
 ORDER BY order_id;
 
 -- The consumer and its view carry no data, so they are rebuilt every time this
@@ -192,6 +195,7 @@ CREATE TABLE IF NOT EXISTS mirror.order_items
     is_deleted UInt8
 )
 ENGINE = ReplacingMergeTree(ver, is_deleted)
+PARTITION BY toYYYYMM(created_at)
 ORDER BY item_id;
 
 -- The consumer and its view carry no data, so they are rebuilt every time this

--- a/k8s/02-configmaps.yaml
+++ b/k8s/02-configmaps.yaml
@@ -120,6 +120,35 @@ data:
               severity: warning
             annotations:
               summary: "Daily revenue is anomalous (z={{ $value }})"
+          # Node disk. Once free space on the root filesystem crosses the
+          # kubelet's nodefs.available threshold (10-15%) the node taints
+          # itself NoSchedule and starts evicting, and the symptoms read as
+          # anything but a disk problem: ContainerStatusUnknown pods, new pods
+          # Pending on an untolerated taint, a node flapping ready. Image
+          # garbage collection cannot rescue it -- it may only remove unused
+          # images, so it reports "0 bytes eligible" while a PersistentVolume
+          # it must not touch holds the space. These fire with room to act.
+          - alert: NodeDiskFillingUp
+            expr: node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} < 0.25
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Node {{ $labels.instance }} below 25% free disk ({{ $value | humanizePercentage }})"
+          - alert: NodeDiskNearEvictionThreshold
+            expr: node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} < 0.18
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Node {{ $labels.instance }} is about to evict pods ({{ $value | humanizePercentage }} free)"
+          - alert: NodeDiskWillFillWithin24h
+            expr: predict_linear(node_filesystem_avail_bytes{mountpoint="/"}[6h], 86400) < 0
+            for: 30m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Node {{ $labels.instance }} will run out of disk within 24h"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/k8s/clickhouse/statefulset.yaml
+++ b/k8s/clickhouse/statefulset.yaml
@@ -45,6 +45,13 @@ spec:
         - name: server-config
           mountPath: /etc/clickhouse-server/config.d/kafka.xml
           subPath: kafka.xml
+        # Bounds ClickHouse's own internal logging (trace_log, metric_log,
+        # ...). Unbounded, these grew to 34G on one node -- most of it two
+        # tables, trace_log and metric_log -- and took the node past the
+        # kubelet's eviction threshold. See #144.
+        - name: server-config
+          mountPath: /etc/clickhouse-server/config.d/02_system_log_retention.xml
+          subPath: 02_system_log_retention.xml
         readinessProbe:
           httpGet:
             path: /ping

--- a/k8s/monitoring/prometheus.yaml
+++ b/k8s/monitoring/prometheus.yaml
@@ -63,6 +63,14 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/prometheus
         - --storage.tsdb.retention.time=7d
+        # A time-only retention is not a size bound: how much disk 7d costs
+        # depends on how many series are being scraped, and this database sits
+        # on an emptyDir, which is node ephemeral storage and counts toward the
+        # kubelet's eviction threshold. Adding more exporters or labels would
+        # otherwise grow it silently until the node began evicting pods --
+        # Prometheus included, which is when the disk graphs go blank.
+        # Whichever limit is reached first wins.
+        - --storage.tsdb.retention.size=2GB
         ports:
         - containerPort: 9090
         volumeMounts:
@@ -82,7 +90,12 @@ spec:
         configMap:
           name: prometheus-config
       - name: prometheus-data
-        emptyDir: {}   # use a PVC in production for persistence
+        emptyDir:
+          # Backstop for the retention limit above. Unbounded, an emptyDir may
+          # consume the whole node filesystem; with a sizeLimit the kubelet
+          # evicts this pod alone rather than letting it take the node's other
+          # workloads down with it. Use a PVC in production for persistence.
+          sizeLimit: 3Gi
 ---
 apiVersion: v1
 kind: Service
@@ -118,6 +131,17 @@ spec:
         args:
         - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
+        # Without --path.rootfs and the mount below, node_filesystem_* describes
+        # this container's filesystem, not the node's. The node can then fill to
+        # the kubelet's eviction threshold -- tainting itself, evicting pods and
+        # refusing to schedule new ones -- while every disk panel stays flat,
+        # because nothing is measuring the disk that ran out. One cluster spent
+        # four days in that state before anyone thought to run df on the node.
+        - --path.rootfs=/host
+        # Pseudo and per-container filesystems only add noise: the overlay and
+        # kubelet mounts are views onto the same root device already reported.
+        - --collector.filesystem.mount-points-exclude=^/host/(dev|proc|sys|run)($|/)
+        - --collector.filesystem.fs-types-exclude=^(autofs|;binfmt_misc|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|pstore|securityfs|shm|squashfs|sysfs|tmpfs|tracefs)$
         ports:
         - containerPort: 9100
         volumeMounts:
@@ -127,6 +151,12 @@ spec:
         - name: sys
           mountPath: /host/sys
           readOnly: true
+        - name: root
+          mountPath: /host
+          readOnly: true
+          # So filesystems mounted on the node after this pod starts are still
+          # visible to it.
+          mountPropagation: HostToContainer
         resources:
           requests:
             memory: "64Mi"
@@ -141,6 +171,9 @@ spec:
       - name: sys
         hostPath:
           path: /sys
+      - name: root
+        hostPath:
+          path: /
 ---
 apiVersion: v1
 kind: Service

--- a/monitoring/alert_rules.yml
+++ b/monitoring/alert_rules.yml
@@ -42,3 +42,49 @@ groups:
         annotations:
           summary: "Daily revenue is anomalous"
           description: "Latest daily revenue is more than 3 standard deviations from the 30-day mean (z={{ $value }})."
+
+      # ── Node disk ──────────────────────────────────────────────────────────
+      # The kubelet evicts pods and taints the node NoSchedule once free space
+      # on the root filesystem falls under its nodefs.available threshold
+      # (10-15% depending on distribution). Past that point the symptoms look
+      # like anything but a disk problem: pods in ContainerStatusUnknown, new
+      # pods Pending on an untolerated taint, a node that flaps in and out of
+      # readiness. These fire while there is still room to act.
+      #
+      # Image garbage collection cannot save a node in this state -- it may
+      # only delete unused images, and it will report "found 0 bytes eligible"
+      # while a PersistentVolume it must not touch holds the space.
+      - alert: NodeDiskFillingUp
+        expr: |
+          node_filesystem_avail_bytes{mountpoint="/"}
+            / node_filesystem_size_bytes{mountpoint="/"} < 0.25
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Node {{ $labels.instance }} root filesystem below 25% free"
+          description: "Only {{ $value | humanizePercentage }} free. The kubelet begins evicting pods at 10-15%. Find the consumer with: du -xh --max-depth=1 / | sort -h | tail"
+
+      - alert: NodeDiskNearEvictionThreshold
+        expr: |
+          node_filesystem_avail_bytes{mountpoint="/"}
+            / node_filesystem_size_bytes{mountpoint="/"} < 0.18
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Node {{ $labels.instance }} is about to start evicting pods"
+          description: "{{ $value | humanizePercentage }} free, against a kubelet eviction threshold of 10-15%. Expect DiskPressure, a NoSchedule taint and evicted pods within hours."
+
+      # Catches a steady leak long before either threshold does -- a volume
+      # growing a few hundred MB an hour trips this days before it trips the
+      # others.
+      - alert: NodeDiskWillFillWithin24h
+        expr: |
+          predict_linear(node_filesystem_avail_bytes{mountpoint="/"}[6h], 24 * 3600) < 0
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Node {{ $labels.instance }} will run out of disk within 24h"
+          description: "Extrapolating the last 6 hours, free space reaches zero inside a day."

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,14 @@
 # runtime image — it omits faker, which is only used by the standalone
 # seed script (make seed), never inside the Airflow container.
 
-apache-airflow==3.3.0
+apache-airflow==3.3.1
+# Not a direct dependency -- dbt-core pulls it in for SQL parsing, and its own
+# pin was capping the resolver below the version that fixes PYSEC-2026-3696/
+# 3697/3698/3699. Floored explicitly because bumping apache-airflow alone
+# left the resolver free to pick 0.5.5 anyway once the rest of this file's
+# packages were installed together; confirmed by a clean-venv install of the
+# full file, not just apache-airflow in isolation.
+sqlparse>=0.6.0
 pandas>=2.1.4
 psycopg2-binary>=2.9.9
 pyarrow>=14.0.1

--- a/scripts/generate_pipeline_assets.py
+++ b/scripts/generate_pipeline_assets.py
@@ -50,6 +50,17 @@ CREATE DATABASE IF NOT EXISTS mirror;
         )
         topic = f"{prefix}.{schema}.{name}"
         group = f"clickhouse-mirror-{name.replace('_', '-')}"
+        # Partitioning is what lets this table shrink again. ReplacingMergeTree
+        # only drops superseded row versions when parts are merged, and
+        # ClickHouse refuses a merge it does not have the free disk to finish.
+        # Unpartitioned, the table is one ever-growing part set, so the merge
+        # that would reclaim space is the first thing skipped once the disk is
+        # tight -- and the table then grows faster. Monthly partitions keep
+        # merges small enough to run, and give `ALTER TABLE ... DROP PARTITION`
+        # as an escape hatch that costs nothing.
+        partition = ''
+        if table.get('partition_column'):
+            partition = f"\nPARTITION BY toYYYYMM({table['partition_column']})"
         out.append(f'''-- ── {name} ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS mirror.{name}
 (
@@ -57,7 +68,7 @@ CREATE TABLE IF NOT EXISTS mirror.{name}
     {'ver'.ljust(width)}UInt64,
     {'is_deleted'.ljust(width)}UInt8
 )
-ENGINE = ReplacingMergeTree(ver, is_deleted)
+ENGINE = ReplacingMergeTree(ver, is_deleted){partition}
 ORDER BY {table['primary_key']};
 
 -- The consumer and its view carry no data, so they are rebuilt every time this

--- a/scripts/test_k8s_spark_driver.sh
+++ b/scripts/test_k8s_spark_driver.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# test_k8s_spark_driver.sh — prove the spark.driver.host fix on real Kubernetes
+#
+# WHY THIS EXISTS
+#   Every Spark fix so far was verified under docker-compose, where the driver's
+#   hostname is the container name and Docker's DNS resolves it. That hides the
+#   bug this tests for. Under KubernetesExecutor the driver runs in a bare task
+#   pod, which has no Service, so nothing in the cluster can resolve its name --
+#   executors cannot call back, and they die on loop.
+#
+# WHAT IT DOES
+#   Runs the same job twice from a bare pod (the shape of a KubernetesExecutor
+#   task pod), differing only in whether spark.driver.host is set:
+#
+#     NEGATIVE  no spark.driver.host  -> driver advertises its pod hostname,
+#                                        executors cannot reach it, no result
+#     POSITIVE  spark.driver.host=IP  -> driver advertises its pod IP,
+#                                        executors connect, job completes
+#
+#   The negative case is the point. A harness that cannot fail proves nothing,
+#   so if NEGATIVE unexpectedly passes, this script says so loudly and treats
+#   the whole run as inconclusive.
+#
+# WHY SparkPi AND NOT THE REAL JOB
+#   SparkPi ships inside the Spark image and needs no --packages, so Ivy never
+#   runs. The real transform jobs pull Iceberg and hadoop-aws at submit time,
+#   and in a bare pod Ivy fails for reasons that have nothing to do with this
+#   bug: HOME is unset, and the image's non-root UID has no /etc/passwd entry
+#   so the JVM cannot resolve user.home. Those are harness artifacts. SparkPi
+#   exercises the one thing under test -- executors calling back to the driver.
+#
+# USAGE
+#   bash scripts/test_k8s_spark_driver.sh
+#
+# REQUIREMENTS
+#   kubectl pointed at a cluster that can pull bitnamilegacy/spark:3.5.0
+
+set -uo pipefail
+
+NAMESPACE="${NAMESPACE:-etl-sparktest}"
+SPARK_IMAGE="bitnamilegacy/spark:3.5.0"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# The negative case hangs rather than erroring -- the driver sits logging
+# "Initial job has not accepted any resources" while executors die and respawn.
+# Bound it so the script terminates.
+NEG_TIMEOUT="${NEG_TIMEOUT:-180}"
+POS_TIMEOUT="${POS_TIMEOUT:-300}"
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; BLUE='\033[0;34m'; NC='\033[0m'
+info()  { echo -e "${BLUE}[INFO]${NC}  $*"; }
+ok()    { echo -e "${GREEN}[OK]${NC}    $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+fail()  { echo -e "${RED}[FAIL]${NC}  $*"; }
+die()   { fail "$*"; exit 1; }
+
+command -v kubectl >/dev/null || die "kubectl not found"
+kubectl cluster-info >/dev/null 2>&1 || die "no reachable cluster (check kubectl config current-context)"
+ok "cluster reachable: $(kubectl config current-context)"
+
+# ── 1. Namespace and the env the worker manifest expects ────────────────────
+# worker-deployment.yaml has envFrom referencing etl-env and etl-secrets. They
+# only carry MinIO/S3A settings, which SparkPi never touches, but a missing
+# reference leaves the pod in CreateContainerConfigError -- so stub them.
+info "Creating namespace $NAMESPACE and stub env"
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+kubectl -n "$NAMESPACE" create configmap etl-env --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+kubectl -n "$NAMESPACE" create secret generic etl-secrets --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+# ── 2. Deploy Spark from the real manifests ─────────────────────────────────
+# Namespace is rewritten so this never touches a real etl deployment.
+info "Deploying Spark from k8s/spark/*.yaml (namespace rewritten to $NAMESPACE)"
+for f in master-deployment.yaml worker-deployment.yaml service.yaml; do
+  sed "s/namespace: etl$/namespace: $NAMESPACE/" "$REPO_ROOT/k8s/spark/$f" \
+    | kubectl apply -n "$NAMESPACE" -f - >/dev/null || die "failed to apply $f"
+done
+
+info "Waiting for spark-master (up to 5m -- first run pulls the image)"
+kubectl -n "$NAMESPACE" rollout status statefulset/spark-master --timeout=300s \
+  || die "spark-master did not become ready"
+info "Waiting for spark-worker"
+kubectl -n "$NAMESPACE" rollout status deployment/spark-worker --timeout=300s \
+  || die "spark-worker did not become ready"
+
+DEPLOYED_IMAGE=$(kubectl -n "$NAMESPACE" get pods -l app=spark-worker \
+  -o jsonpath='{.items[0].spec.containers[0].image}')
+ok "workers running $DEPLOYED_IMAGE"
+[ "$DEPLOYED_IMAGE" = "$SPARK_IMAGE" ] \
+  || warn "expected $SPARK_IMAGE -- version parity (#130) may not be in this tree"
+
+# ── 3. The test itself ──────────────────────────────────────────────────────
+# Bare pod, no Service, restartPolicy=Never: the shape of a KubernetesExecutor
+# task pod. That absence of a Service is precisely what makes driver.host matter.
+run_case() {
+  local name="$1" driver_conf="$2" timeout_s="$3" podname="sparktest-$1-$RANDOM"
+
+  info "── $name case: submitting SparkPi from a bare pod (no Service)"
+  timeout "$timeout_s" kubectl -n "$NAMESPACE" run "$podname" \
+    --image="$SPARK_IMAGE" --restart=Never --attach --rm -q \
+    --command -- bash -c "
+      JAR=\$(ls /opt/bitnami/spark/examples/jars/spark-examples_*.jar 2>/dev/null | head -1)
+      echo \"POD_HOSTNAME=\$(hostname)\"
+      echo \"POD_IP=\$(hostname -i | cut -d' ' -f1)\"
+      /opt/bitnami/spark/bin/spark-submit \
+        --master spark://spark-master:7077 \
+        $driver_conf \
+        --conf spark.driver.bindAddress=0.0.0.0 \
+        --conf spark.executor.memory=1g \
+        --conf spark.cores.max=2 \
+        --class org.apache.spark.examples.SparkPi \
+        \$JAR 10 2>&1
+    " 2>&1
+  return $?
+}
+
+echo
+echo "═══════════════════════════════════════════════════════════════════"
+echo " NEGATIVE — driver advertises its pod hostname (the bug)"
+echo "═══════════════════════════════════════════════════════════════════"
+NEG_OUT=$(run_case "negative" "" "$NEG_TIMEOUT"); NEG_RC=$?
+echo "$NEG_OUT" | tail -25
+kubectl -n "$NAMESPACE" delete pod -l run --ignore-not-found >/dev/null 2>&1
+
+echo
+echo "═══════════════════════════════════════════════════════════════════"
+echo " POSITIVE — driver advertises its pod IP (the fix, as shipped in #129)"
+echo "═══════════════════════════════════════════════════════════════════"
+POS_OUT=$(run_case "positive" \
+  '--conf spark.driver.host=$(hostname -i | cut -d" " -f1)' "$POS_TIMEOUT"); POS_RC=$?
+echo "$POS_OUT" | tail -25
+
+# ── 4. Verdict ──────────────────────────────────────────────────────────────
+echo
+echo "═══════════════════════════════════════════════════════════════════"
+echo " VERDICT"
+echo "═══════════════════════════════════════════════════════════════════"
+neg_got_pi=0; pos_got_pi=0
+grep -q "Pi is roughly" <<<"$NEG_OUT" && neg_got_pi=1
+grep -q "Pi is roughly" <<<"$POS_OUT" && pos_got_pi=1
+
+echo "  negative: rc=$NEG_RC  computed Pi: $([ $neg_got_pi -eq 1 ] && echo YES || echo no)"
+echo "  positive: rc=$POS_RC  computed Pi: $([ $pos_got_pi -eq 1 ] && echo YES || echo no)"
+echo
+
+if [ $neg_got_pi -eq 1 ]; then
+  warn "INCONCLUSIVE — the negative case succeeded, so this harness does not"
+  warn "reproduce the bug and proves nothing about the fix. Most likely the"
+  warn "cluster resolves bare pod hostnames (some CNI/DNS setups do), which"
+  warn "means it is not reproducing Raghu's environment."
+  exit 2
+elif [ $pos_got_pi -eq 1 ]; then
+  ok "CONFIRMED — negative fails, positive succeeds."
+  ok "spark.driver.host=\$(hostname -i) is what makes executors reach the driver."
+  exit 0
+else
+  fail "BOTH cases failed. The fix is not the differentiator here -- something"
+  fail "else is broken (workers unregistered, image pull, resources). Check:"
+  fail "  kubectl -n $NAMESPACE get pods"
+  fail "  kubectl -n $NAMESPACE logs -l app=spark-worker --tail=50"
+  exit 1
+fi

--- a/ui/src/proxy.ts
+++ b/ui/src/proxy.ts
@@ -9,6 +9,24 @@ import type { NextRequest } from 'next/server';
  * the dashboard stays open — sensible for local development, but set a
  * password on any shared or cluster deployment.
  */
+/**
+ * Compare two strings without leaking how far they matched.
+ *
+ * `===` on a secret returns as soon as it hits a differing character, so the
+ * response time carries the length of the matching prefix. Walking the full
+ * width every time removes that signal. Written by hand rather than with
+ * node:crypto's timingSafeEqual because this runs in the Edge runtime, where
+ * the node crypto module is unavailable.
+ */
+function safeEqual(a: string, b: string): boolean {
+  const width = Math.max(a.length, b.length);
+  let mismatch = a.length ^ b.length;
+  for (let i = 0; i < width; i++) {
+    mismatch |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
+  }
+  return mismatch === 0;
+}
+
 export function proxy(request: NextRequest) {
   const expectedPassword = process.env.DASHBOARD_AUTH_PASSWORD;
   if (!expectedPassword) {
@@ -20,7 +38,7 @@ export function proxy(request: NextRequest) {
   if (header.startsWith('Basic ')) {
     try {
       const [user, ...rest] = atob(header.slice(6)).split(':');
-      if (user === expectedUser && rest.join(':') === expectedPassword) {
+      if (safeEqual(user, expectedUser) && safeEqual(rest.join(':'), expectedPassword)) {
         return NextResponse.next();
       }
     } catch {


### PR DESCRIPTION
## Summary

Started as verification for the `spark.driver.host` fix on real KubernetesExecutor (#126's driver-host theory). That led to #126/#141/#144 — a node repeatedly crossing the kubelet's disk-eviction threshold — and each fix here closes one confirmed cause, in the order they were found.

- **Spark driver-host, on Kubernetes.** `scripts/test_k8s_spark_driver.sh` submits SparkPi twice from a bare pod — the shape of a KubernetesExecutor task pod, no Service — once without `spark.driver.host` and once with it. Reports a verdict rather than a pass/fail: if the negative case unexpectedly succeeds, it says so and calls the run inconclusive instead of green, because a harness that can't fail proves nothing.
- **Secrets out of rendered Airflow commands.** MinIO and Postgres passwords were interpolated into `bash_command` in `spark_transform_silver.py`, which Airflow persists in the metadata DB, the task log, and the UI's "Rendered Template" pane. Moved to task `env`, referenced as `$VAR` in the command string.
- **Constant-time dashboard auth.** The Basic Auth check in `ui/src/proxy.ts` used `===` on the password, which returns as soon as it hits a differing byte — the response time leaks the length of the matching prefix. Hand-rolled compare (Edge runtime, no `node:crypto`) that always walks the full width.
- **AI dashboard as a Compose service.** `k8s/ui/deployment.yaml` ran it; Compose had no service at all, and the README's documented path was `npm run dev -- -p 3001` by hand. Added a proper service. Dropped Metabase alongside it — no config, no provisioning, ephemeral H2, wired to nothing.
- **ClickHouse mirror tables partitioned.** They were `ReplacingMergeTree` with no `PARTITION BY`, so superseded row versions only ever drop on a merge, and a merge that can't get free disk is the first thing skipped — the table then grows faster, not slower. `pipeline_config.py` rejects a partition column that's missing, non-temporal, or listed in `update_columns` (partitioning on a mutable column scatters one row's versions across partitions where nothing, not even `FINAL`, can recollapse them). No TTL — these mirror current state, so age-based deletion would drop rows still live in the source.
- **node-exporter was blind to the disk that filled.** It mounted only `/proc` and `/sys` — never root — so `node_filesystem_*` reported the exporter container's own filesystem the entire time. A node could cross the eviction threshold, taint itself, and start evicting pods while every disk panel stayed flat. Fixed in both Compose and Kubernetes, plus three new alerts (25% warning, 18% critical — just above the kubelet's own 10–15% threshold, and a `predict_linear` rule for a slow leak neither catches). Bounded Prometheus's own `emptyDir` too, since it's node ephemeral storage counted toward the same threshold.
- **Docs for two traps that cost real time on a live cluster.** A `Pending` pod naming a taint needs the opposite fix from one naming `Insufficient memory`/`cpu`, and they look identical at a glance. And `local-path` PVC sizes are labels with no quota behind them — `volumeClaimTemplates` are immutable, so shrinking one later isn't a live edit.
- **ClickHouse's own system tables were the actual 34G**, not the mirror. `#144` on a live cluster: `mirror.*` totalled under 1MB (`count()` matched `count() FINAL` exactly — no duplication to reclaim), while `system.trace_log`/`system.metric_log` accounted for the bulk of the 34G, confirmed by `TRUNCATE` timing (13.2s / 11.9s vs. under a tenth of a second for every other system table). Both log continuously by default — `trace_log` samples roughly once a second per running query, and the mirror's Kafka Engine tables poll continuously, so they're always "running." `metric_log` snapshots unconditionally every second. New `docker/clickhouse/config.d/02_system_log_retention.xml` gives every default system log table a daily partition and a short TTL, mounted the same single-file way as the existing `kafka.xml` (mounting the whole `config.d` directory masks the image's own config and breaks bind-to-loopback).

## Verification

- `scripts/test_k8s_spark_driver.sh` — negative/positive A/B, not run in this environment (container registry pulls are blocked here); written to run on a real cluster, and the driver-host mechanism it tests is independently confirmed by production evidence in #126.
- `docker compose config -q`, `yamllint k8s/ monitoring/ docker-compose.yml`, `python scripts/generate_pipeline_assets.py --check`, `ruff check`, `mypy` — all pass.
- `promtool check rules` against both the Compose and Kubernetes alert rule sets.
- `xmllint --noout` against the new ClickHouse config (caught and fixed real double-hyphen-in-comment errors — XML rejects `--` inside comments).
- `pipeline_config.py`'s new partition-column guard negative-tested directly: rejects a mutable column, a non-existent column, and a non-temporal column, each with the reason in the error.
- The disk-alert PromQL and the `partition_column` manifest validation were checked against the actual production incident data in #126/#144 after the fact, not just synthetically.

## Deploying this

- **Spark DAG fix**: DAG-file-only, picked up by git-sync automatically.
- **ClickHouse partitioning**: only applies to newly created mirror tables — `CREATE TABLE IF NOT EXISTS` won't repartition an existing one, and ClickHouse can't `ALTER` a partition key. Existing clusters pick it up by dropping and recreating the four mirror tables (safe — Postgres is the source of truth, the materialized views resume from committed Kafka offsets).
- **System log retention**: needs `clickhouse-0` restarted — `config.d` is read at startup only. `kubectl rollout restart statefulset/clickhouse -n etl`, or the next `deploy.sh` run.
- **Compose dashboard service, node-exporter mounts, alert rules**: live on the next `docker compose up -d` / `deploy.sh`.

