### PR TITLE
fix(clickhouse): close the gaps #144 left in the retention config

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -363,6 +363,58 @@ Once `DiskPressure` returns to `False`, the rejected pods schedule on their own.
 kubectl delete pod -n etl --field-selector status.phase=Failed
 ```
 
+### A config file change did not take effect
+
+Editing a file under `docker/clickhouse/config.d/` and restarting the pod does nothing on Kubernetes. Under Compose the file is bind-mounted, so an edit plus a restart is genuinely the whole story — that difference is what makes this easy to get wrong.
+
+On Kubernetes the file reaches the container through three links, and every one of them has to be updated:
+
+1. **The ConfigMap.** `deploy.sh` builds `clickhouse-config` from the whole directory *at deploy time* (`k8s/deploy.sh:256`). Your checkout is not mounted into the cluster; a `git pull` alone changes nothing the pod can see.
+2. **The mount.** Each file gets its own `subPath` entry in `k8s/clickhouse/statefulset.yaml`. Mounting the directory whole would replace the image's `docker_related_config.xml`, which sets `listen_host` — without it the server binds loopback only and every probe gets connection refused. So **a new file needs a new mount**, and a mount only exists in the cluster once the manifest has been applied.
+3. **The pod.** `config.d` is read at startup, so the pod must restart.
+
+`kubectl rollout restart` on its own only does the third. It restarts pods against the StatefulSet spec **already in the cluster**, so a mount added in the repo but never applied does not exist as far as the restart is concerned.
+
+Re-running the deploy does all three:
+
+```bash
+SEED=n bash k8s/deploy.sh
+```
+
+Verify by looking in the container rather than trusting the output:
+
+```bash
+kubectl exec -n etl clickhouse-0 -- ls /etc/clickhouse-server/config.d/
+```
+
+Every file you expect should be listed. If one is missing, its `subPath` mount is missing — no amount of restarting will change that.
+
+Do **not** apply the raw manifest by hand:
+
+```bash
+kubectl apply -f k8s/clickhouse/statefulset.yaml   # will be rejected
+```
+
+The file carries `storageClassName: standard` and `deploy.sh` rewrites that to your actual StorageClass (`k8s/deploy.sh:128`). Since `volumeClaimTemplates` is immutable, the apply fails with a `Forbidden: updates to statefulset spec for fields other than...` error that names the storage class rather than whatever you were trying to change. To skip a full deploy, patch the pod template only:
+
+```bash
+kubectl patch statefulset clickhouse -n etl --type=json \
+  -p='[{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"server-config","mountPath":"/etc/clickhouse-server/config.d/<file>.xml","subPath":"<file>.xml"}}]'
+```
+
+### ClickHouse system tables keep their old settings after a config change
+
+`02_system_log_retention.xml` sets a partition key and TTL on ClickHouse's internal log tables. ClickHouse will not rewrite an existing table to match: at startup it renames the old one aside — `text_log` becomes `text_log_0`, then `text_log_1` — and creates a fresh empty table with the new definition.
+
+New writes are bounded immediately, but **the old data stays on disk under the renamed table** and no TTL applies to it. Applying the retention config therefore reclaims nothing by itself. List them and drop them:
+
+```sql
+SHOW TABLES FROM system LIKE '%log%';
+DROP TABLE system.text_log_0;   -- repeat for each numeric suffix
+```
+
+The same renaming happens on a ClickHouse version upgrade, so a long-lived cluster accumulates these whether or not anyone edits the config.
+
 ### A test step fails
 
 ```bash

--- a/docker/clickhouse/config.d/02_system_log_retention.xml
+++ b/docker/clickhouse/config.d/02_system_log_retention.xml
@@ -7,15 +7,19 @@
       monthly waits weeks before ALTER ... DROP PARTITION has anything to
       drop.
 
-      trace_log samples a stack trace roughly once a second per running
-      query, and every Kafka Engine table in mirror/01_mirror_schema.sql
-      polls continuously, so it is effectively always "running a query".
-      metric_log snapshots the whole system.metrics/system.events set once a
-      second, unconditionally, whether or not anything is happening.
-      Nineteen days of both, uncapped, was 34G on one node: point for point
-      where #144's TRUNCATE landed, at 13.2s and 11.9s respectively versus
-      under a tenth of a second for every other system table cleared in the
-      same session.
+      Two tables were nearly all of the 34G that took a node down in #144.
+      trace_log, at 29G, samples a stack trace roughly once a second per
+      running query, and every Kafka Engine table in
+      mirror/01_mirror_schema.sql polls continuously, so it is effectively
+      always "running a query". text_log, at 5.2G across 98 million rows, is
+      the server's own log written into a table, which is off by default in
+      stock ClickHouse but on in the image this stack runs.
+
+      An earlier revision of this comment named metric_log as the second of
+      the two, on the strength of its 11.9s TRUNCATE next to trace_log's
+      13.2s. Mapping the store directories to table names later showed that
+      was wrong: metric_log runs under 10 MiB a day. TRUNCATE time tracks part
+      count, not bytes, and the two only correlate until they don't.
 
       Daily partitions plus a short TTL bound it going forward. This does not
       touch anything under `mirror`: Kafka Engine, materialized views, and
@@ -23,9 +27,24 @@
 
       Not every table below is guaranteed to exist in every ClickHouse
       version: system.query_thread_log, for one, was folded into
-      system.query_log some releases back. A config block for a table this
+      system.query_log some releases back, and latency_log and
+      query_metric_log only appeared in 25.x. A config block for a table this
       build does not have is inert, not an error, so this stays exhaustive
       rather than probing each cluster's exact version first.
+
+      That cuts both ways, and the first version of this file got it wrong in
+      the other direction: it was written from ClickHouse's documented set of
+      default system tables rather than from `SHOW TABLES FROM system` on the
+      cluster that was actually on fire, so latency_log, error_log and
+      query_metric_log were simply absent. All three are small today. Being
+      small is not the same as being bounded, which is the entire lesson of
+      #144, so they are here now.
+
+      Adding a file to this directory is never only a file change on
+      Kubernetes: each one needs its own subPath mount in
+      k8s/clickhouse/statefulset.yaml, because mounting the directory whole
+      would mask the image's docker_related_config.xml. See
+      DEPLOY_GUIDE.md for the full sequence.
     -->
 
     <query_log>
@@ -60,14 +79,32 @@
         <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </part_log>
 
-    <!-- The two confirmed by #144: 29G and 5.2G of the 34G that took the
-         node down, at roughly matching truncate times. Short TTL, and daily
-         partitions so that TTL has something cheap to drop. -->
+    <!-- The single largest table in #144: 29G of the 34G, on its own.
+         Resolving the store directories to table names afterwards also
+         corrected the pairing this comment used to claim - the 5.2G runner up
+         was text_log, not metric_log, which turned out to be under 10 MiB a day.
+
+         1 day, not the 3 the rest get, because #144 left behind an actual
+         measurement instead of a guess. After the incident TRUNCATE emptied
+         it, trace_log was back to 645 MiB across 45,012,156 rows in roughly
+         six hours: about 2.4 GiB a day, near 2,000 rows a second. That is the
+         profiler working as designed rather than a fault, since every Kafka
+         Engine table in mirror/01_mirror_schema.sql polls without pause and
+         so always looks like a running query to it. At that rate 3 days is
+         some 7 GiB held permanently, a third of the 20Gi volume, for stack
+         traces nobody on this project has ever read. 1 day keeps it useful
+         for diagnosing something that broke this morning and costs 2.4 GiB.
+
+         Turning the profiler off outright would cost nothing measurable and
+         reclaim that too, via query_profiler_real_time_period_ns=0 and
+         query_profiler_cpu_time_period_ns=0 in the default profile. It is
+         deliberately not done here: a profiler you disabled is one you will
+         not have on the day you need it, and 2.4 GiB is affordable. -->
     <trace_log>
         <database>system</database>
         <table>trace_log</table>
         <partition_by>toYYYYMMDD(event_date)</partition_by>
-        <ttl>event_date + INTERVAL 3 DAY DELETE</ttl>
+        <ttl>event_date + INTERVAL 1 DAY DELETE</ttl>
         <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </trace_log>
 
@@ -118,4 +155,34 @@
         <ttl>event_date + INTERVAL 3 DAY DELETE</ttl>
         <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </processors_profile_log>
+
+    <!-- The three 25.x additions the first revision of this file did not know
+         about, found by listing system tables on the affected cluster rather
+         than trusting the documented default set. On that cluster, after 20
+         days: latency_log 22.85 MiB, error_log 574 KiB, query_metric_log 237 KiB. All
+         negligible, none of them bounded, which is the same sentence that
+         described trace_log 20 days before it was 29G. -->
+    <latency_log>
+        <database>system</database>
+        <table>latency_log</table>
+        <partition_by>toYYYYMMDD(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 3 DAY DELETE</ttl>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </latency_log>
+
+    <error_log>
+        <database>system</database>
+        <table>error_log</table>
+        <partition_by>toYYYYMMDD(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </error_log>
+
+    <query_metric_log>
+        <database>system</database>
+        <table>query_metric_log</table>
+        <partition_by>toYYYYMMDD(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </query_metric_log>
 </clickhouse>


### PR DESCRIPTION
Follow-up to #146. Three gaps in the system-log retention config, plus the deploy trap that kept the fix from reaching the cluster at all.

They are all the same kind of mistake: the first pass was written from the repo and the ClickHouse docs, and the running cluster disagreed. Every correction here comes from evidence in #144 rather than from re-reading the code.

## Three system tables were missing

The config enumerated ClickHouse's *documented* set of default log tables instead of what `SHOW TABLES FROM system` actually returns on the 25.3 build this stack runs. So `latency_log`, `error_log` and `query_metric_log` were never bounded.

After 20 days on the affected cluster they were 22.85 MiB, 574 KiB and 237 KiB. Negligible — which is precisely what `trace_log` looked like 20 days before it was 29G. Small is not the same as bounded.

## `trace_log` drops to a 1 day TTL

The incident `TRUNCATE` left a clean zero point, and refilling from it produced the first real growth rate anyone has had for this table:

```
trace_log   645.28 MiB   45,012,156 rows   oldest 2026-08-20   newest 2026-08-20
```

Six hours. Roughly 2.4 GiB/day, near 2,000 rows/second. That is the query profiler working as designed — every Kafka Engine table in `mirror/01_mirror_schema.sql` polls without pause, so it always looks like a running query.

At 3 days that is ~7 GiB held permanently, a third of the 20Gi claim, for stack traces nobody on this project has ever read. 1 day still covers "what broke this morning" and costs 2.4 GiB.

Disabling the profiler outright would reclaim that too, and the config notes how. It is deliberately not done: a profiler you turned off is one you will not have on the day you need it.

## The header comment named the wrong table

It credited `trace_log` and `metric_log` with the 34G, reasoning from their `TRUNCATE` times (13.2s and 11.9s, against under 0.1s for everything else). Resolving the store directory UUIDs to table names showed otherwise:

| | |
|---|---|
| `trace_log` | 29G |
| `text_log` | 5.2G, 98,181,433 rows |
| `metric_log` | under 10 MiB/day |

The 5.2G runner-up was `text_log`, ClickHouse's own server log written into a table. `TRUNCATE` time tracks part count, not bytes; the two correlate until they don't.

## `DEPLOY_GUIDE.md`: why the fix did not reach the cluster

This is the part that cost real time in #144, and it is a genuine trap in this repo rather than a one-off mistake.

Under Compose the file is bind-mounted, so editing it and restarting is the whole story. On Kubernetes it travels three links — ConfigMap → `subPath` mount → pod — and `kubectl rollout restart` only does the last one. It restarts pods against the StatefulSet spec **already in the cluster**, so a mount that exists in the repo but was never applied does not exist as far as the restart is concerned. Adding a file to `config.d/` is never only a file change.

Two more things the guide now says, both discovered the hard way:

- `kubectl apply -f k8s/clickhouse/statefulset.yaml` by hand is rejected. `deploy.sh` rewrites `storageClassName` at deploy time (`k8s/deploy.sh:128`) and `volumeClaimTemplates` is immutable, so the error names the storage class rather than the mount you were trying to add. `SEED=n bash k8s/deploy.sh`, or a targeted `kubectl patch` of the pod template.
- Applying this config reclaims nothing on its own. ClickHouse will not rewrite an existing system table to match a new partition key — it renames the old one aside (`text_log_0`, `text_log_1`, …) and creates a fresh one. New writes are bounded immediately; the old data stays on disk under the renamed table with no TTL on it, and has to be dropped explicitly. The same renaming happens on a version upgrade, which is where the affected cluster's seven July `_0` tables came from.

## Validation

- `xmllint --noout` on the config — clean
- `yamllint k8s/ monitoring/ docker-compose.yml .github/` (CI's exact invocation) — clean
- `docker compose config -q` — clean
- `python scripts/generate_pipeline_assets.py --check` — in sync

Not verified on a live cluster from here; the ClickHouse behaviour above is drawn from the `_0` tables and query output in #144 rather than from a local reproduction.

Refs #144


---
_Generated by [Claude Code](https://claude.ai/code/session_01SvzgLnboGXum8b6vhPUynX)_