### PR TITLE
Name the table holding the disk, and correct the trace_log rate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,25 @@ jobs:
         run: |
           pip install yamllint
           yamllint k8s/ monitoring/ docker-compose.yml .github/
+      - name: XML well-formedness
+        # A malformed file under docker/clickhouse/config.d/ is not a lint
+        # nit: ClickHouse parses config.d at startup and refuses to boot, so
+        # the failure surfaces as an unschedulable pod on deploy rather than
+        # here. Comments in these files carry incident write-ups, and XML
+        # comments cannot contain a double hyphen, which is exactly how one
+        # gets broken while being edited.
+        run: |
+          python -c "
+          import glob, sys, xml.etree.ElementTree as ET
+          bad = 0
+          for f in sorted(glob.glob('docker/**/*.xml', recursive=True)):
+              try:
+                  ET.parse(f)
+                  print('ok   ' + f)
+              except ET.ParseError as e:
+                  print('FAIL ' + f + ': ' + str(e)); bad = 1
+          sys.exit(bad)
+          "
 
   markdown-lint:
     runs-on: ubuntu-latest

--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -357,6 +357,11 @@ df -h /
 sudo du -xh --max-depth=1 / | sort -h | tail -10
 ```
 
+If that points at a PersistentVolume rather than a Docker or containerd store,
+the workload inside it is the thing to look at. For ClickHouse — the largest
+claim in this stack, and the one that took a node down in #144 — see
+[Which ClickHouse table is using the space](#which-clickhouse-table-is-using-the-space).
+
 Once `DiskPressure` returns to `False`, the rejected pods schedule on their own. This just tidies the list:
 
 ```bash
@@ -401,6 +406,50 @@ The file carries `storageClassName: standard` and `deploy.sh` rewrites that to y
 kubectl patch statefulset clickhouse -n etl --type=json \
   -p='[{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"server-config","mountPath":"/etc/clickhouse-server/config.d/<file>.xml","subPath":"<file>.xml"}}]'
 ```
+
+### Which ClickHouse table is using the space
+
+The node-level `du` above tells you the ClickHouse volume is large. It cannot
+tell you which table filled it, and the answer is rarely the one people expect.
+Ask the server:
+
+```sql
+SELECT database, table,
+       formatReadableSize(sum(bytes_on_disk)) AS size,
+       sum(rows) AS rows, count() AS parts,
+       min(min_date) AS oldest, max(max_date) AS newest
+FROM system.parts
+WHERE active
+GROUP BY database, table
+ORDER BY sum(bytes_on_disk) DESC
+LIMIT 20;
+```
+
+Expect `system` to dominate and `mirror` to be small. On one cluster the four
+mirror tables came to under 600 KiB between them while `system.trace_log` alone
+held 750 MiB. That is the normal shape rather than a fault: the mirror stores
+one row per source row, and the profiler stores a sampled stack trace per
+running query per second — and every Kafka Engine table polls without pause, so
+the server always looks busy to it.
+
+`oldest` and `newest` read `1970-01-01` for the `mirror` tables. Those two
+columns are only populated for a `Date`-derived partition key, and the mirror
+partitions on a `DateTime64` (`PARTITION BY toYYYYMM(created_at)`), so they stay
+at the epoch. It says nothing about the data — read `system.parts.partition`
+instead.
+
+To look at the mirror on its own:
+
+```sql
+SELECT table, formatReadableSize(sum(bytes_on_disk)) AS size,
+       sum(rows) AS rows, count() AS parts
+FROM system.parts WHERE database = 'mirror' AND active
+GROUP BY table ORDER BY sum(bytes_on_disk) DESC;
+```
+
+If a large table under `system` has a name ending in a number, the retention
+config has been applied and the old unbounded copy is still on disk — which is
+the next section.
 
 ### ClickHouse system tables keep their old settings after a config change
 

--- a/docker/clickhouse/config.d/02_system_log_retention.xml
+++ b/docker/clickhouse/config.d/02_system_log_retention.xml
@@ -25,6 +25,19 @@
       touch anything under `mirror`: Kafka Engine, materialized views, and
       the ReplacingMergeTree tables they feed are untouched.
 
+      The daily partitions are also what keeps the TTL itself cheap, which is
+      not automatic. TTL deletion in ClickHouse rewrites whole parts to drop
+      expired rows, so a TTL cutting through the middle of a part pays to
+      rewrite every row it keeps. The pathological report is a 1% delete
+      that wrote 3.17TB to remove 269 million rows out of 27 billion.
+      Partitioning by day and expiring in whole days means every part that
+      expires is entirely past its TTL, so the files are dropped rather than
+      rewritten. Anything added here later needs that same alignment between
+      partition granularity and TTL granularity. The mirror tables carry no TTL
+      at all, deliberately, since a replica holds what the source holds, and they
+      partition monthly, so a TTL added there without changing the partition
+      key would land in exactly the expensive case.
+
       Not every table below is guaranteed to exist in every ClickHouse
       version: system.query_thread_log, for one, was folded into
       system.query_log some releases back, and latency_log and
@@ -85,15 +98,25 @@
          was text_log, not metric_log, which turned out to be under 10 MiB a day.
 
          1 day, not the 3 the rest get, because #144 left behind an actual
-         measurement instead of a guess. After the incident TRUNCATE emptied
-         it, trace_log was back to 645 MiB across 45,012,156 rows in roughly
-         six hours: about 2.4 GiB a day, near 2,000 rows a second. That is the
-         profiler working as designed rather than a fault, since every Kafka
-         Engine table in mirror/01_mirror_schema.sql polls without pause and
-         so always looks like a running query to it. At that rate 3 days is
-         some 7 GiB held permanently, a third of the 20Gi volume, for stack
-         traces nobody on this project has ever read. 1 day keeps it useful
-         for diagnosing something that broke this morning and costs 2.4 GiB.
+         measurement instead of a guess. Two measurements now, and the second
+         corrects the first. Six hours after the incident TRUNCATE emptied it,
+         trace_log held 645 MiB across 45,012,156 rows: near 2,000 rows a
+         second, which extrapolates to about 2.4 GiB a day. A full day of
+         steady state came in well below that: 750 MiB across 51,863,815 rows
+         for a single event_date, about 900 MiB a day at some 735 rows a
+         second. The six-hour window was measured while the server was still
+         working through post-TRUNCATE merges, so it read hot, and
+         extrapolating from it overstated the rate by nearly a factor of
+         three. Sample a partition that has actually finished.
+
+         Either way this is the profiler working as designed rather than a
+         fault, since every Kafka Engine table in mirror/01_mirror_schema.sql
+         polls without pause and so always looks like a running query to it.
+         At the corrected rate 3 days is about 2.7 GiB rather than the 7 GiB
+         the first estimate implied. Affordable at both numbers, so this
+         stays at 1 day for the reason that did not change: nobody on this
+         project has ever read a stack trace out of it. 1 day costs some
+         900 MiB and still answers "what was the server doing this morning".
 
          Turning the profiler off outright would cost nothing measurable and
          reclaim that too, via query_profiler_real_time_period_ns=0 and


### PR DESCRIPTION
Three things from the tail of #144, where the incident is now closed on the reporting cluster (ClickHouse PVC 6.8G -> 842M, DiskPressure clear on both nodes, 29 pods steady).

## The two queries, as asked for

`DEPLOY_GUIDE.md` could take you from a `DiskPressure` node to `du` on the host, and then stopped. Nothing named the table holding the space, which is the step that actually ends the investigation — on that cluster the four mirror tables came to under 600 KiB while `system.trace_log` alone held 750 MiB.

Both `system.parts` queries now live in a new **Which ClickHouse table is using the space** section, linked from the DiskPressure section.

One addition they need: `min_date`/`max_date` read `1970-01-01` for every `mirror` table, because those columns are only populated for a `Date`-derived partition key and the mirror partitions on a `DateTime64` (`PARTITION BY toYYYYMM(created_at)`). Documented, so the epoch is not read as data loss by the next person to run it.

## The trace_log rate was overstated

`02_system_log_retention.xml` claimed ~2.4 GiB/day and reasoned from it: *"3 days is some 7 GiB held permanently, a third of the 20Gi volume."*

That came from a six-hour window measured while the server was still working through post-`TRUNCATE` merges, so it read hot. A full steady-state `event_date` is **750 MiB across 51,863,815 rows, about 900 MiB/day at ~735 rows/second** — nearly 3x lower. So the 3-day option would have been ~2.7 GiB, not 7 GiB.

The TTL stays at **1 day**. The reason for it never rested on the arithmetic (nobody on this project has ever read a stack trace out of that table), and re-churning a config that is deployed and working buys nothing. But a comment doing load-bearing reasoning should not do it from a hot sample, so the numbers are corrected and the lesson is recorded: sample a partition that has finished.

## The TTL write-amplification question

Raised on the same thread, via [a report of a 1% delete that wrote 3.17TB](https://medium.com/@amrelboridy7/your-ttl-is-working-that-might-be-the-problem-3ed30cdb1492) to remove 269 million rows out of 27 billion.

It does not apply to the tables in this file, and the reason is worth writing down rather than leaving to luck: TTL deletion rewrites whole parts to drop expired rows, so a TTL cutting through the middle of a part pays to rewrite everything it keeps. Partitioning by day and expiring in whole days means every expiring part is entirely past its TTL, so ClickHouse drops the files instead.

The follow-up observation on the thread — that it *"applies to the data tables as well"* — is the sharper half. The mirror tables carry no TTL at all, deliberately, since a replica holds what the source holds. They also partition **monthly**, so a TTL added there later without changing the partition key would land in exactly the expensive case. Now noted in the file.

## CI: XML well-formedness

I broke that XML while editing this, by writing `--` inside an XML comment, which is illegal. Nothing in CI would have caught it.

That is not a lint nit here. `config.d` is parsed at ClickHouse startup, so a malformed file surfaces as a pod that will not boot on the next deploy, several minutes and one `git pull` away from the edit that caused it. And these files carry incident write-ups in their comments, so a double hyphen is a realistic way to break one.

One step added to the existing lint job. Verified it fails on a malformed file, not only that it passes on the current ones.

## Verification

| Check | Result |
|---|---|
| `python -m yamllint .github/` | clean |
| `markdownlint-cli2 DEPLOY_GUIDE.md` | clean |
| XML check, current files | pass (2 files) |
| XML check, deliberately malformed file | fails with exit 1 |

Refs #144.