### PR TITLE
Cover all three pipelines in the e2e test, and stop passing checks that never ran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
           python scripts/generate_pipeline_assets.py --check
       - name: Verify dashboard and alert metrics exist in the statsd mapping
         run: python scripts/check_dashboard_metrics.py
+      - name: Verify the e2e suite cannot report a pass it did not earn
+        # See #149: the suite reported a healthy pipeline while never
+        # reading the lakehouse. Runs offline, no cluster needed.
+        run: |
+          pip install requests psycopg2-binary faker
+          python scripts/ci/test_e2e_accounting.py
 
   type-check:
     runs-on: ubuntu-latest

--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -155,7 +155,11 @@ trino-worker-xxx (x2)               1/1     Running
 bash scripts/test_e2e.sh
 ```
 
-This port-forwards the services, seeds 200 orders, runs the extract → MinIO → warehouse pipeline, fires live transactions (updates, cancellations, hard deletes), and verifies the ClickHouse mirror caught every change. Expected ending:
+This port-forwards the services, seeds 200 orders, runs the extract → MinIO →
+warehouse pipeline, fires live transactions (updates, cancellations, hard
+deletes), verifies the ClickHouse mirror caught every change, reads the Iceberg
+lakehouse through Trino, and checks the dbt marts are built and populated —
+one assertion per pipeline. Expected ending:
 
 ```text
   ✓  Seeded 200 orders into postgres-source
@@ -166,10 +170,29 @@ This port-forwards the services, seeds 200 orders, runs the extract → MinIO �
   ✓  Row count matches
   ✓  All 5 deleted orders are gone from the mirror
   ✓  All 10 cancellations reflected in the mirror
+  ✓  Iceberg tables present
+  ✓  Lakehouse is readable and populated
+  ✓  dbt marts present
+  ✓  dbt marts populated
 
-  Total: 9 passed, 0 failed
-  All checks passed — pipeline is healthy!
+  Total: 12 passed, 0 failed, 0 skipped
+
+  All checks passed — all three pipelines verified end to end:
+    Pipe 1  warehouse: dbt int/gold marts built and populated
+    Pipe 2  lakehouse: iceberg.lake.orders readable through Trino
+    Pipe 3  mirror:    counts, deletes and cancellations in ClickHouse
 ```
+
+A **skipped** check is not a passing one. If Trino is unreachable the lakehouse
+step reports `~` and the summary says the pipeline behind it is UNVERIFIED,
+rather than counting it green and claiming the stack is healthy — which is what
+it used to do, for as long as it never read the lakehouse at all (#149).
+
+The lakehouse and mart checks read what the DAGs produced, so they need at least
+one successful run of `ingest_source_to_bronze` and `spark_transform_silver`
+behind them. On a cluster deployed minutes ago they will fail honestly rather
+than pass vacuously; give the hourly schedules a run, or trigger both DAGs from
+the Airflow UI first.
 
 ### Step 6 — Open the dashboards
 

--- a/scripts/ci/test_e2e_accounting.py
+++ b/scripts/ci/test_e2e_accounting.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Guard the result accounting in scripts/test_transactions.py.
+
+#149 was not a missing feature, it was a suite that reported a healthy
+pipeline while two of three pipelines went unchecked. The fix is only worth
+anything for as long as a skipped check keeps counting as a skip, so that
+property gets a test rather than a comment.
+
+Runs offline: importing test_transactions touches no cluster, and the paths
+exercised here are the ones that fire when an endpoint is absent.
+"""
+
+import contextlib
+import importlib.util
+import io
+import os
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent
+
+
+def load():
+    os.environ.pop("TRINO_URL", None)
+    spec = importlib.util.spec_from_file_location(
+        "tt", SCRIPTS / "test_transactions.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["tt"] = module
+    spec.loader.exec_module(module)   # the __main__ guard keeps the suite from running
+    return module
+
+
+def run(module):
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        try:
+            module.summary()
+        except SystemExit:
+            pass
+    return buf.getvalue()
+
+
+def main():
+    tt = load()
+
+    # An unconfigured lakehouse is a skip, never a pass.
+    assert tt.TRINO_URL == "", f"TRINO_URL should be empty, got {tt.TRINO_URL!r}"
+    with contextlib.redirect_stdout(io.StringIO()):
+        tt.verify_lakehouse()
+    assert tt.results, "verify_lakehouse recorded nothing at all"
+    assert [r[0] for r in tt.results] == ["SKIP"], tt.results
+
+    # One skip alongside real passes must not report a healthy pipeline.
+    tt.results.append(("PASS", "a real check"))
+    out = run(tt)
+    assert "UNVERIFIED" in out, out
+    assert "all three pipelines verified" not in out, out
+
+    # A clean sweep may claim coverage, and must name all three pipelines.
+    tt.results[:] = [("PASS", "a"), ("PASS", "b")]
+    out = run(tt)
+    assert "all three pipelines verified" in out, out
+    for pipe in ("Pipe 1", "Pipe 2", "Pipe 3"):
+        assert pipe in out, f"{pipe} missing from the coverage summary:\n{out}"
+
+    # A failure still exits non-zero and never claims coverage.
+    tt.results[:] = [("PASS", "a"), ("FAIL", "b")]
+    out = run(tt)
+    assert "Some checks failed" in out, out
+    assert "all three pipelines verified" not in out, out
+
+    print("e2e result accounting: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -62,6 +62,10 @@ fwd postgres-dest   5434 5432
 fwd kafka-connect   8084 8083
 fwd minio           9000 9000
 fwd clickhouse      8123 8123
+# Pipe 2 lives behind Trino. Without this forward the lakehouse check cannot
+# run at all, which is exactly how it went unnoticed that it never ran (#149).
+# 8085 locally because 8082 is Trino under docker-compose and may be in use.
+fwd trino           8085 8080
 
 # Give port-forwards a moment to settle
 sleep 3
@@ -125,6 +129,7 @@ export DEST_DB_PORT=5434
 export KAFKA_CONNECT_URL="http://localhost:8084"
 export MINIO_ENDPOINT="http://localhost:9000"
 export CLICKHOUSE_URL="http://localhost:8123"
+export TRINO_URL="http://localhost:8085"
 
 SOURCE_DB_NAME=$(sv SOURCE_DB_NAME sourcedb);            export SOURCE_DB_NAME
 SOURCE_DB_USER=$(sv SOURCE_DB_USER sourceuser);          export SOURCE_DB_USER
@@ -146,7 +151,7 @@ set -e
 echo ""
 if [ $TEST_EXIT -eq 0 ]; then
   echo -e "${GREEN}============================================================${NC}"
-  echo -e "${GREEN}  ALL TESTS PASSED — pipeline is healthy!${NC}"
+  echo -e "${GREEN}  ALL CHECKS PASSED — see the per-pipeline summary above${NC}"
   echo -e "${GREEN}============================================================${NC}"
 else
   echo -e "${RED}============================================================${NC}"

--- a/scripts/test_transactions.py
+++ b/scripts/test_transactions.py
@@ -11,7 +11,17 @@ What this tests:
   Step 4  Simulate live transactions: UPDATE status, CANCEL orders, DELETE rows
   Step 5  Verify the ClickHouse mirror (Pipe 3's real consumer) reflects
           every change: counts, deletes gone, cancellations applied
-  Step 6  Print pass / fail report
+  Step 6  Verify the Iceberg lakehouse (Pipe 2) is readable through Trino
+  Step 7  Verify the dbt marts (Pipe 1) exist and are populated
+  Step 8  Print pass / fail / skip report
+
+Coverage, stated honestly (#149): Step 3 reproduces the ingestion DAG's
+writes rather than triggering the DAG, so Pipes 1 and 2 are checked by their
+outputs -- the dbt marts and the Iceberg tables can only be there if the real
+DAG and its dbt task group ran. Steps 6 and 7 report SKIP, never PASS, when
+their endpoint is not configured, because a check that cannot run is not a
+check that passed. The final line names what was verified instead of claiming
+the whole pipeline is healthy.
 
 Usage (local docker-compose):
   DEST_DB_PORT=5433 MINIO_ROOT_PASSWORD=minioadmin python scripts/test_transactions.py
@@ -59,6 +69,8 @@ MINIO_PASSWORD  = os.environ.get("MINIO_ROOT_PASSWORD", "minioadmin123")
 CLICKHOUSE_URL  = os.environ.get("CLICKHOUSE_URL", "http://localhost:8123")
 CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "chuser")
 CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD", "chpass")
+# Unset means "not deployed here", which is a skip rather than a failure.
+TRINO_URL       = os.environ.get("TRINO_URL", "")
 CHUNK_DIR       = os.path.join(tempfile.gettempdir(), "etl_test_chunks")
 
 STATUSES  = ["pending", "processing", "shipped", "delivered", "cancelled"]
@@ -87,6 +99,20 @@ def fail(msg, detail=""):
         tag += f"  ({detail})"
     print(tag)
     results.append(("FAIL", msg))
+
+
+def skip(msg, detail=""):
+    """Record a check that could not run.
+
+    Deliberately not a pass. Counting an unrunnable check as green is how this
+    suite came to report a healthy pipeline while never reading the lakehouse
+    at all (#149).
+    """
+    tag = f"  ~  {msg}"
+    if detail:
+        tag += f"  ({detail})"
+    print(tag)
+    results.append(("SKIP", msg))
 
 
 # ── Step 1: Seed source database ──────────────────────────────────────────────
@@ -482,20 +508,172 @@ def verify_clickhouse(txn, max_order_id):
         print(f"  {status:<15} {count:>6}")
 
 
-# ── Step 6: Summary ───────────────────────────────────────────────────────────
+# ── Step 6: Lakehouse (Pipe 2) ────────────────────────────────────────────────
+def trino_query(sql):
+    """Run one statement over Trino's REST protocol, following nextUri.
+
+    Results arrive across pages and the first page usually carries no rows at
+    all, so a naive single POST reads an empty result and calls it a passing
+    zero. Follow the chain to the end.
+    """
+    r = requests.post(
+        f"{TRINO_URL}/v1/statement",
+        data=sql.encode("utf-8"),
+        headers={"X-Trino-User": "e2e-test"},
+        timeout=30,
+    )
+    rows = []
+    while True:
+        r.raise_for_status()
+        page = r.json()
+        if page.get("error"):
+            raise RuntimeError(page["error"].get("message", "unknown Trino error"))
+        rows.extend(page.get("data") or [])
+        nxt = page.get("nextUri")
+        if not nxt:
+            return rows
+        r = requests.get(nxt, headers={"X-Trino-User": "e2e-test"}, timeout=30)
+
+
+def verify_lakehouse():
+    step("STEP 6 — Verify the Iceberg lakehouse (Pipe 2) through Trino")
+
+    if not TRINO_URL:
+        skip(
+            "Lakehouse not checked — TRINO_URL unset",
+            "set TRINO_URL (test_e2e.sh port-forwards it) to verify Pipe 2",
+        )
+        return
+
+    try:
+        tables = {r[0] for r in trino_query(
+            "SELECT table_name FROM iceberg.information_schema.tables "
+            "WHERE table_schema = 'lake'"
+        )}
+    except Exception as e:
+        fail("Trino is not answering", str(e)[:200])
+        return
+
+    if "orders" not in tables:
+        fail(
+            "iceberg.lake.orders does not exist",
+            "the Spark silver job has never completed. Check the "
+            "spark_transform_silver DAG, and that the iceberg_catalog schema "
+            "exists in postgres-dest",
+        )
+        return
+    ok("Iceberg tables present", ", ".join(sorted(tables)))
+
+    try:
+        lake_count = int(trino_query("SELECT count(*) FROM iceberg.lake.orders")[0][0])
+    except Exception as e:
+        fail("Could not read iceberg.lake.orders", str(e)[:200])
+        return
+
+    if lake_count > 0:
+        ok("Lakehouse is readable and populated", f"{lake_count} rows in iceberg.lake.orders")
+    else:
+        fail(
+            "iceberg.lake.orders is empty",
+            "the table exists but no Spark run has merged bronze into it",
+        )
+        return
+
+    # Deliberately not asserted equal to the source. Pipe 2 is batch, so it
+    # trails by up to one run -- and the MERGE never deletes, so the five rows
+    # this test hard-deletes from the source stay in the lake for good. A test
+    # demanding equality here would fail correctly-behaving infrastructure.
+    src = psycopg2.connect(**SOURCE)
+    with src.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM orders")
+        src_count = cur.fetchone()[0]
+    src.close()
+    print("")
+    print(f"  source={src_count}  lake={lake_count}  "
+          "(batch lag plus merge-only semantics: the lake keeps deleted rows)")
+
+
+# ── Step 7: Warehouse marts (Pipe 1) ──────────────────────────────────────────
+def verify_warehouse_marts():
+    step("STEP 7 — Verify the dbt marts (Pipe 1) are built and populated")
+
+    # Step 3 writes raw.orders_source itself, so finding rows there proves
+    # nothing about the DAG. int/gold can only exist if the real dbt task
+    # group ran, which makes them the honest signal for Pipe 1.
+    expected = [
+        ("int", "orders_clean"),
+        ("gold", "fact_order_items"),
+        ("gold", "dim_customer"),
+        ("gold", "dim_date"),
+    ]
+    dest = psycopg2.connect(**DEST)
+    try:
+        with dest.cursor() as cur:
+            cur.execute(
+                "SELECT table_schema, table_name FROM information_schema.tables "
+                "WHERE table_schema IN ('int', 'gold')"
+            )
+            present = {(r[0], r[1]) for r in cur.fetchall()}
+
+            missing = [f"{sc}.{tb}" for sc, tb in expected if (sc, tb) not in present]
+            if missing:
+                fail(
+                    "dbt marts missing: " + ", ".join(missing),
+                    "the dbt task group in ingest_source_to_bronze has not run "
+                    "successfully. raw.* being populated says nothing here, "
+                    "because step 3 of this test writes it directly",
+                )
+                return
+            ok("dbt marts present", f"{len(expected)} of {len(expected)} in int/gold")
+
+            empty = []
+            for schema, table in expected:
+                # identifiers come from the list above, never from input
+                cur.execute(f'SELECT count(*) FROM "{schema}"."{table}"')  # nosec B608
+                if cur.fetchone()[0] == 0:
+                    empty.append(f"{schema}.{table}")
+            if empty:
+                fail(
+                    "dbt marts built but empty: " + ", ".join(empty),
+                    "dbt ran against a raw layer it could not read, or the "
+                    "quality filters in the int models dropped every row",
+                )
+            else:
+                ok("dbt marts populated", "int and gold both hold rows")
+    finally:
+        dest.close()
+
+
+# ── Step 8: Summary ───────────────────────────────────────────────────────────
 def summary():
-    step("STEP 6 — Test Summary")
+    step("STEP 8 — Test Summary")
     passed = sum(1 for r in results if r[0] == "PASS")
     failed = sum(1 for r in results if r[0] == "FAIL")
+    skipped = sum(1 for r in results if r[0] == "SKIP")
+    icons = {"PASS": "✓", "FAIL": "✗", "SKIP": "~"}
     for status, msg in results:
-        icon = "✓" if status == "PASS" else "✗"
-        print(f"  {icon}  {msg}")
-    print(f"\n  Total: {passed} passed, {failed} failed")
+        print(f"  {icons[status]}  {msg}")
+    print("")
+    print(f"  Total: {passed} passed, {failed} failed, {skipped} skipped")
+
     if failed:
-        print("\n  Some checks failed — review the output above for details.")
+        print("")
+        print("  Some checks failed — review the output above for details.")
         sys.exit(1)
+
+    # A green run has to say what it actually covered. Reporting "pipeline is
+    # healthy" off a suite that never read the lakehouse is the whole of #149,
+    # and it held for weeks while Pipe 2 had no successful Trino read at all.
+    print("")
+    if skipped:
+        print(f"  {passed} passed, but {skipped} skipped — the "
+              f"pipelines behind them are UNVERIFIED, not healthy.")
+        print("  Configure the endpoints named above and re-run to cover all three.")
     else:
-        print("\n  All checks passed — pipeline is healthy!")
+        print("  All checks passed — all three pipelines verified end to end:")
+        print("    Pipe 1  warehouse: dbt int/gold marts built and populated")
+        print("    Pipe 2  lakehouse: iceberg.lake.orders readable through Trino")
+        print("    Pipe 3  mirror:    counts, deletes and cancellations in ClickHouse")
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────
@@ -515,4 +693,6 @@ if __name__ == "__main__":
     txn = simulate_transactions()
 
     verify_clickhouse(txn, max_order_id=200)
+    verify_lakehouse()
+    verify_warehouse_marts()
     summary()


### PR DESCRIPTION
Closes #149.

`test_e2e.sh` printed `ALL TESTS PASSED — pipeline is healthy!` on 9/9 while exercising Pipe 3 and nothing else. It printed that same banner throughout the weeks when Pipe 2 had no successful Trino read on record.

## What was missing

| Pipeline | Covered before | Covered now |
|---|---|---|
| Pipe 1 warehouse | `raw.*` only, written by the test itself | `int` + `gold` marts, which only the real dbt task group can create |
| Pipe 2 lakehouse | nothing — no `trino`/`iceberg`/`lake`/`silver` anywhere in the harness | `iceberg.lake.orders` read through Trino |
| Pipe 3 mirror | counts, deletes, cancellations | unchanged |

## Step 6 — lakehouse

Reads `iceberg.lake.orders` over Trino's REST protocol, following the `nextUri` chain rather than trusting the first page — that page usually carries no rows, so a single POST would read a passing zero.

Asserts the table exists and holds rows. **Deliberately does not assert equality with the source:** Pipe 2 is batch so it trails by up to one run, and the MERGE never deletes, so the five rows this test hard-deletes stay in the lake for good. A test demanding equality there would fail correctly-behaving infrastructure. Both counts are printed so the divergence is visible instead of asserted away.

## Step 7 — warehouse marts

Not `raw.*` — step 3 writes that directly, so rows there say nothing about the DAG. `int.orders_clean` and the `gold` star schema can only exist if the real dbt task group ran, which makes them the honest signal. Built-but-empty is reported separately from missing, since the causes differ.

## The accounting, which is the more important half

An unconfigured endpoint now records **SKIP**, and any run with a skip refuses to claim health — it names the unverified pipelines instead. A clean run states which three pipelines it verified rather than asserting the stack is fine.

Counting an unrunnable check as green is what let this suite mislead for weeks. Same failure mode as #105.

`scripts/ci/test_e2e_accounting.py` holds the property in place — skip stays a skip, a skip suppresses the health claim, a clean sweep names all three pipelines, a failure still exits non-zero. Offline, no cluster, wired into `pipeline-config-sync`.

## Verification

| Check | Result |
|---|---|
| `ruff check airflow/ scripts/ spark/ sample-data/` | clean |
| `bandit -r … -ll` | exit 0 |
| `yamllint .github/` | clean |
| `markdownlint-cli2 DEPLOY_GUIDE.md` | clean |
| `bash -n scripts/test_e2e.sh` | clean |
| `scripts/ci/test_e2e_accounting.py` | passes |
| same, with `skip()` regressed to record a pass | **fails, exit 1** |

That last row is the one that matters — the guard was confirmed to have teeth, not just to be green today.

## One caveat for fresh clusters

Steps 6 and 7 read what the DAGs produced, so they need one successful run of `ingest_source_to_bronze` and `spark_transform_silver` behind them. On a stack deployed minutes ago they fail honestly rather than pass vacuously. DEPLOY_GUIDE Step 5 now says so.