### PR TITLE
Stop the silver jobs succeeding at doing nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,14 @@ jobs:
           python scripts/ci/test_e2e_accounting.py
       - name: Verify the Bronze load contract
         # A Spark job that succeeds at doing nothing is how Pipe 2 stayed
-        # broken while its DAG was green (#149). Fakes stand in for Spark,
-        # so this needs no cluster.
-        run: python scripts/ci/test_bronze_guard.py
+        # broken while its DAG was green (#149). Fakes stand in for a Spark
+        # session, so no cluster is needed -- but pyspark itself is, because
+        # the check that matters asserts recursiveFileLookup is set on the
+        # real reader, and dropping that assertion to avoid the install would
+        # leave the silent-failure mode unguarded.
+        run: |
+          pip install pyspark==3.5.0
+          python scripts/ci/test_bronze_guard.py
 
   type-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
         run: |
           pip install requests psycopg2-binary faker
           python scripts/ci/test_e2e_accounting.py
+      - name: Verify the Bronze load contract
+        # A Spark job that succeeds at doing nothing is how Pipe 2 stayed
+        # broken while its DAG was green (#149). Fakes stand in for Spark,
+        # so this needs no cluster.
+        run: python scripts/ci/test_bronze_guard.py
 
   type-check:
     runs-on: ubuntu-latest

--- a/airflow/dags/spark_transform_silver.py
+++ b/airflow/dags/spark_transform_silver.py
@@ -48,7 +48,11 @@ with DAG(
     tags=['spark', 'iceberg', 'silver', 'scalability', 'compaction'],
 ) as dag:
 
-    # Every date below falls back to "now" when the run has no interval.
+    # The maintenance gate below falls back to "now" when the run has no
+    # interval. The four transform tasks used to take a date too, and no
+    # longer do: the Spark jobs read every retained Bronze partition rather
+    # than one day's, so a day they missed is merged on the next run instead
+    # of being pruned away unmerged (see spark/jobs/bronze.py).
     #
     # In Airflow 3 a manually triggered run has logical_date=None unless one is
     # passed explicitly, and the whole family of macros derived from it --
@@ -141,28 +145,28 @@ with DAG(
 
     transform_orders = BashOperator(
         task_id='transform_orders',
-        bash_command=get_spark_submit_command('Orders-Bronze-to-Silver', '/opt/spark-jobs/transform_orders.py', '{{ (data_interval_end | default(macros.datetime.utcnow())).strftime("%Y%m%d") }}'),
+        bash_command=get_spark_submit_command('Orders-Bronze-to-Silver', '/opt/spark-jobs/transform_orders.py'),
         env=SPARK_SECRET_ENV,
         append_env=True,
     )
 
     transform_customers = BashOperator(
         task_id='transform_customers',
-        bash_command=get_spark_submit_command('Customers-Bronze-to-Silver', '/opt/spark-jobs/transform_customers.py', '{{ (data_interval_end | default(macros.datetime.utcnow())).strftime("%Y%m%d") }}'),
+        bash_command=get_spark_submit_command('Customers-Bronze-to-Silver', '/opt/spark-jobs/transform_customers.py'),
         env=SPARK_SECRET_ENV,
         append_env=True,
     )
 
     transform_products = BashOperator(
         task_id='transform_products',
-        bash_command=get_spark_submit_command('Products-Bronze-to-Silver', '/opt/spark-jobs/transform_products.py', '{{ (data_interval_end | default(macros.datetime.utcnow())).strftime("%Y%m%d") }}'),
+        bash_command=get_spark_submit_command('Products-Bronze-to-Silver', '/opt/spark-jobs/transform_products.py'),
         env=SPARK_SECRET_ENV,
         append_env=True,
     )
 
     transform_order_items = BashOperator(
         task_id='transform_order_items',
-        bash_command=get_spark_submit_command('OrderItems-Bronze-to-Silver', '/opt/spark-jobs/transform_order_items.py', '{{ (data_interval_end | default(macros.datetime.utcnow())).strftime("%Y%m%d") }}'),
+        bash_command=get_spark_submit_command('OrderItems-Bronze-to-Silver', '/opt/spark-jobs/transform_order_items.py'),
         env=SPARK_SECRET_ENV,
         append_env=True,
     )

--- a/scripts/ci/test_bronze_guard.py
+++ b/scripts/ci/test_bronze_guard.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Guard the Bronze load contract in spark/jobs/bronze.py.
+
+The bug this protects against did not look like a bug. Four Spark jobs read a
+Bronze partition that did not exist, returned None, and exited 0, so
+spark_transform_silver was green for days on a cluster where
+iceberg.lake.orders had never been created (#149).
+
+The distinction that matters is between "no new rows to merge", which is a
+legitimate empty run, and "no Bronze data and no target table", which means
+the lakehouse was never initialised. The first must return None, the second
+must raise. That is the whole contract, and it gets a test rather than a
+comment.
+
+Fakes stand in for Spark: none of these paths call anything but count() and
+catalog.tableExists(), so a session is not needed and this runs in CI.
+"""
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "spark" / "jobs"))
+
+
+class FakeCatalog:
+    def __init__(self, exists):
+        self._exists = exists
+        self.asked = []
+
+    def tableExists(self, name):   # noqa: N802 - mirrors the PySpark API
+        self.asked.append(name)
+        return self._exists
+
+
+class FakeSpark:
+    def __init__(self, table_exists):
+        self.catalog = FakeCatalog(table_exists)
+
+
+class FakeDF:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def count(self):
+        return self._rows
+
+
+def main():
+    import bronze
+
+    # 1. No Bronze data and no table: the lakehouse was never initialised.
+    #    This is the case that used to exit 0 and take Pipe 2 down silently.
+    with mock.patch.object(bronze, "read_all_partitions", return_value=None):
+        try:
+            bronze.load_bronze(FakeSpark(table_exists=False), "orders", "silver.lake.orders")
+        except RuntimeError as e:
+            assert "never been initialised" in str(e), str(e)
+            assert "silver.lake.orders" in str(e), str(e)
+            assert "ingest_source_to_bronze" in str(e), "error should say what to check"
+        else:
+            raise AssertionError("no data and no table must raise, not return")
+
+    # 2. An empty frame is the same condition as no frame at all.
+    with mock.patch.object(bronze, "read_all_partitions", return_value=FakeDF(0)):
+        try:
+            bronze.load_bronze(FakeSpark(table_exists=False), "orders", "silver.lake.orders")
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("an empty frame with no table must raise too")
+
+    # 3. No Bronze data but the table exists: a genuinely quiet run.
+    with mock.patch.object(bronze, "read_all_partitions", return_value=None):
+        assert bronze.load_bronze(
+            FakeSpark(table_exists=True), "orders", "silver.lake.orders"
+        ) is None
+
+    # 4. Rows present: hand them back, and do not consult the catalog at all.
+    df = FakeDF(42)
+    spark = FakeSpark(table_exists=False)
+    with mock.patch.object(bronze, "read_all_partitions", return_value=df):
+        assert bronze.load_bronze(spark, "orders", "silver.lake.orders") is df
+    assert spark.catalog.asked == [], "the happy path should not need tableExists"
+
+    # 5. The reader must target the table prefix, not one dated partition.
+    #    Reading a single day is what let retention prune unmerged partitions.
+    spark = mock.MagicMock()
+    bronze.read_all_partitions(spark, "orders")
+    assert spark.read.option.call_args[0] == ("recursiveFileLookup", "true"), (
+        "recursiveFileLookup is load-bearing: the dated directories are not "
+        "Hive-style key=value, so without it Spark infers no schema and the "
+        "prefix read silently comes back empty. Verified against MinIO."
+    )
+    path = spark.read.option.return_value.parquet.call_args[0][0]
+    assert path == "s3a://bronze/orders_source/", path
+
+    print("bronze load contract: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/spark/jobs/bronze.py
+++ b/spark/jobs/bronze.py
@@ -1,0 +1,84 @@
+"""Shared Bronze reader for the Silver transform jobs.
+
+Every one of the four transform jobs used to carry its own copy of this, and
+every copy had the same two faults. #149's new lakehouse check found the
+result: `iceberg.lake.orders` did not exist on a cluster whose
+spark_transform_silver DAG had been green for days.
+
+Fault one — success at doing nothing. Ingestion is incremental, so a run with
+no new source rows writes no Bronze parquet at all. Each job then read the
+missing path, caught AnalysisException, returned None, and main() returned. The
+task exited 0. Nothing distinguished "no new rows to merge", which is a genuine
+no-op, from "the table has never been created", which is a broken pipeline. A
+cluster reported three consecutive successful runs at 3m27s while the lakehouse
+did not exist.
+
+Fault two — only today's partition was ever read. Bronze is pruned after 7
+days (BRONZE_RETENTION_DAYS), and the jobs read exactly one day, so any day the
+Spark side did not run was pruned before anything merged it and was gone from
+the lake permanently. Nothing detected that either: the following day's run
+read the following day's partition and reported success.
+
+Both are fixed here rather than in four places.
+"""
+
+import os
+
+from pyspark.errors import AnalysisException
+
+
+def read_all_partitions(spark, source_table):
+    """Read every retained Bronze partition for `source_table`.
+
+    Reads the table prefix rather than one YYYY/MM/DD partition under it, so
+    Spark discovers whatever is there and a day the job missed is merged on the
+    next run instead of being lost when retention prunes it.
+
+    The cost is re-merging up to BRONZE_RETENTION_DAYS of parquet on every run.
+    MERGE is keyed on the primary key so that is idempotent, just not free: at
+    a volume where it stops being cheap, track merged partitions and read only
+    the unmerged ones, which needs state this pipeline does not currently keep.
+    """
+    bucket = os.environ.get('BRONZE_BUCKET', 'bronze')
+    path = f"s3a://{bucket}/{source_table}_source/"
+    print(f"Reading Bronze layer from: {path}")
+    try:
+        # recursiveFileLookup is required, not optional. The dated directories
+        # under the prefix are plain YYYY/MM/DD, not Hive-style key=value, so
+        # without it Spark treats them as partition directories, infers no
+        # schema and raises AnalysisException on a prefix that plainly holds
+        # parquet. Verified: the prefix read comes back empty without it.
+        df = spark.read.option("recursiveFileLookup", "true").parquet(path)
+    except AnalysisException:
+        return None
+    return df
+
+
+def load_bronze(spark, source_table, iceberg_table):
+    """Return the Bronze DataFrame, or None when there is genuinely nothing to do.
+
+    Raises when there is no Bronze data *and* the target Iceberg table does not
+    exist. That combination is not a quiet day, it is a lakehouse that was
+    never initialised, and reporting it as success is what hid #149's failure
+    for as long as it did.
+    """
+    df = read_all_partitions(spark, source_table)
+    count = df.count() if df is not None else 0
+
+    if count == 0:
+        if not spark.catalog.tableExists(iceberg_table):
+            raise RuntimeError(
+                f"No Bronze data for '{source_table}' and {iceberg_table} does "
+                f"not exist, so the lakehouse has never been initialised. This "
+                f"is a failure, not an empty run.\n"
+                f"  Check that ingest_source_to_bronze has completed at least "
+                f"once and wrote s3a://{os.environ.get('BRONZE_BUCKET', 'bronze')}"
+                f"/{source_table}_source/, and that Bronze retention "
+                f"(BRONZE_RETENTION_DAYS) has not pruned every partition."
+            )
+        print(f"No Bronze data for '{source_table}'; {iceberg_table} already "
+              f"exists, so there is nothing to merge.")
+        return None
+
+    print(f"Loaded {count} records from Bronze")
+    return df

--- a/spark/jobs/transform_customers.py
+++ b/spark/jobs/transform_customers.py
@@ -5,7 +5,7 @@ Uses Iceberg MERGE INTO for high-performance incremental dimension updates.
 
 import os
 import sys
-from pyspark.errors import AnalysisException
+from bronze import load_bronze
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, current_timestamp, trim, lower
 
@@ -17,17 +17,6 @@ def create_spark_session():
         .appName("Customers-Bronze-to-Silver-Incremental") \
         .master(master_url) \
         .getOrCreate()
-
-
-def read_from_bronze(spark, date_path):
-    bronze_path = f"s3a://bronze/customers_source/{date_path}/"
-    print(f"Reading Customer Bronze layer from: {bronze_path}")
-    try:
-        return spark.read.parquet(bronze_path)
-    except AnalysisException:
-        # Ingestion writes no files on days with zero new rows
-        print(f"No Bronze data at {bronze_path} — nothing to transform today.")
-        return None
 
 
 def transform_customers(df):
@@ -87,20 +76,14 @@ def upsert_to_iceberg(spark, df):
 
 
 def main():
-    if len(sys.argv) < 2:
-        from datetime import datetime
-        date_str = datetime.now().strftime("%Y%m%d")
-    else:
-        date_str = sys.argv[1]
-
-    # Convert 20260405 to 2026/04/05 for S3 path
-    formatted_date = f"{date_str[:4]}/{date_str[4:6]}/{date_str[6:]}"
-
+    # No date argument: load_bronze reads every retained Bronze
+    # partition, so a day this job missed is merged on the next run
+    # rather than pruned away unmerged.
     spark = create_spark_session()
     
     try:
-        print(f"Starting Spark Job: Customer Bronze to Silver — date: {date_str}")
-        bronze_df = read_from_bronze(spark, formatted_date)
+        print("Starting Spark Job: Customer Bronze to Silver")
+        bronze_df = load_bronze(spark, "customers", "silver.lake.customers")
         if bronze_df is None:
             return
         silver_df = transform_customers(bronze_df)

--- a/spark/jobs/transform_order_items.py
+++ b/spark/jobs/transform_order_items.py
@@ -5,7 +5,7 @@ Uses Iceberg MERGE INTO for high-performance incremental transaction line-item u
 
 import os
 import sys
-from pyspark.errors import AnalysisException
+from bronze import load_bronze
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, current_timestamp
 
@@ -17,17 +17,6 @@ def create_spark_session():
         .appName("OrderItems-Bronze-to-Silver-Incremental") \
         .master(master_url) \
         .getOrCreate()
-
-
-def read_from_bronze(spark, date_path):
-    bronze_path = f"s3a://bronze/order_items_source/{date_path}/"
-    print(f"Reading OrderItems Bronze layer from: {bronze_path}")
-    try:
-        return spark.read.parquet(bronze_path)
-    except AnalysisException:
-        # Ingestion writes no files on days with zero new rows
-        print(f"No Bronze data at {bronze_path} — nothing to transform today.")
-        return None
 
 
 def transform_order_items(df):
@@ -79,20 +68,14 @@ def upsert_to_iceberg(spark, df):
 
 
 def main():
-    if len(sys.argv) < 2:
-        from datetime import datetime
-        date_str = datetime.now().strftime("%Y%m%d")
-    else:
-        date_str = sys.argv[1]
-
-    # Convert 20260405 to 2026/04/05 for S3 path
-    formatted_date = f"{date_str[:4]}/{date_str[4:6]}/{date_str[6:]}"
-
+    # No date argument: load_bronze reads every retained Bronze
+    # partition, so a day this job missed is merged on the next run
+    # rather than pruned away unmerged.
     spark = create_spark_session()
     
     try:
-        print(f"Starting Spark Job: OrderItems Bronze to Silver — date: {date_str}")
-        bronze_df = read_from_bronze(spark, formatted_date)
+        print("Starting Spark Job: OrderItems Bronze to Silver")
+        bronze_df = load_bronze(spark, "order_items", "silver.lake.order_items")
         if bronze_df is None:
             return
         silver_df = transform_order_items(bronze_df)

--- a/spark/jobs/transform_orders.py
+++ b/spark/jobs/transform_orders.py
@@ -3,13 +3,11 @@ Spark Job: Transform Orders from Bronze to Silver (Elite Scalability)
 Uses Iceberg MERGE INTO for high-performance incremental upserts.
 """
 
-from pyspark.errors import AnalysisException
+from bronze import load_bronze
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, current_timestamp
 from pyspark.sql.types import DecimalType
-from datetime import datetime
 import os
-import sys
 
 
 def create_spark_session():
@@ -19,24 +17,6 @@ def create_spark_session():
         .appName("Orders-Bronze-to-Silver-Incremental") \
         .master(master_url) \
         .getOrCreate()
-
-
-def read_from_minio(spark, date):
-    """Read Bronze layer from MinIO — partitioned by date"""
-    bronze_bucket = os.environ.get('BRONZE_BUCKET', 'bronze')
-    # date format: YYYYMMDD → convert to YYYY/MM/DD partition path
-    year, month, day = date[:4], date[4:6], date[6:]
-    path = f"s3a://{bronze_bucket}/orders_source/{year}/{month}/{day}/"
-
-    print(f"Reading Bronze layer from: {path}")
-    try:
-        df = spark.read.parquet(path)
-    except AnalysisException:
-        # Ingestion writes no files on days with zero new rows
-        print(f"No Bronze data at {path} — nothing to transform today.")
-        return None
-    print(f"Loaded {df.count()} records from Bronze")
-    return df
 
 
 def transform_to_silver(df):
@@ -74,10 +54,6 @@ def upsert_to_iceberg(spark, df):
     table_name = f"{catalog_name}.lake.orders"
     spark.sql(f"CREATE NAMESPACE IF NOT EXISTS {catalog_name}.lake")
 
-    if df.count() == 0:
-        print(f"No records to upsert to {table_name}. Skipping.")
-        return
-
     # 1. Create table if not exists (first run)
     if not spark.catalog.tableExists(table_name):
         print(f"Creating new Iceberg table: {table_name}")
@@ -110,16 +86,13 @@ def upsert_to_iceberg(spark, df):
 
 
 def main():
-    if len(sys.argv) < 2:
-        date = datetime.now().strftime("%Y%m%d")
-        print(f"No date provided, using today: {date}")
-    else:
-        date = sys.argv[1]
-
+    # No date argument: load_bronze reads every retained Bronze partition, so
+    # a day this job missed is merged on the next run rather than pruned away
+    # unmerged.
     spark = create_spark_session()
 
     try:
-        bronze_df = read_from_minio(spark, date)
+        bronze_df = load_bronze(spark, "orders", "silver.lake.orders")
         if bronze_df is None:
             return
         silver_df = transform_to_silver(bronze_df)

--- a/spark/jobs/transform_products.py
+++ b/spark/jobs/transform_products.py
@@ -5,7 +5,7 @@ Uses Iceberg MERGE INTO for high-performance incremental catalog updates.
 
 import os
 import sys
-from pyspark.errors import AnalysisException
+from bronze import load_bronze
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, current_timestamp, trim, lower
 
@@ -17,17 +17,6 @@ def create_spark_session():
         .appName("Products-Bronze-to-Silver-Incremental") \
         .master(master_url) \
         .getOrCreate()
-
-
-def read_from_bronze(spark, date_path):
-    bronze_path = f"s3a://bronze/products_source/{date_path}/"
-    print(f"Reading Product Bronze layer from: {bronze_path}")
-    try:
-        return spark.read.parquet(bronze_path)
-    except AnalysisException:
-        # Ingestion writes no files on days with zero new rows
-        print(f"No Bronze data at {bronze_path} — nothing to transform today.")
-        return None
 
 
 def transform_products(df):
@@ -84,20 +73,14 @@ def upsert_to_iceberg(spark, df):
 
 
 def main():
-    if len(sys.argv) < 2:
-        from datetime import datetime
-        date_str = datetime.now().strftime("%Y%m%d")
-    else:
-        date_str = sys.argv[1]
-
-    # Convert 20260405 to 2026/04/05 for S3 path
-    formatted_date = f"{date_str[:4]}/{date_str[4:6]}/{date_str[6:]}"
-
+    # No date argument: load_bronze reads every retained Bronze
+    # partition, so a day this job missed is merged on the next run
+    # rather than pruned away unmerged.
     spark = create_spark_session()
     
     try:
-        print(f"Starting Spark Job: Product Bronze to Silver — date: {date_str}")
-        bronze_df = read_from_bronze(spark, formatted_date)
+        print("Starting Spark Job: Product Bronze to Silver")
+        bronze_df = load_bronze(spark, "products", "silver.lake.products")
         if bronze_df is None:
             return
         silver_df = transform_products(bronze_df)


### PR DESCRIPTION
#149's lakehouse check found this on its first run against Raghu's cluster: `iceberg.lake.orders` does not exist, on a stack whose `spark_transform_silver` DAG has been green for days.

Not a config problem on that cluster — two bugs, each in four copies.

## Fault 1 — success at doing nothing

Ingestion is incremental, so a run with no new source rows writes **no** Bronze parquet for that day. Each transform job then read the missing partition, caught `AnalysisException`, returned `None`, and `main()` returned. **Exit 0.**

Nothing separated *"no new rows to merge"* — a real no-op — from *"the target table has never been created"* — a broken pipeline.

That is exactly why #126 shows three consecutive successful runs at 3m27s next to a table that has never existed. The runs succeeded at skipping.

## Fault 2 — only today's partition was ever read

Bronze is pruned after `BRONZE_RETENTION_DAYS`; the jobs read exactly one day. So **any day the Spark side did not run was pruned before anything merged it** — a permanent hole in the lake, undetectable, because the next day's run reads the next day's partition and reports success.

## The fix

`spark/jobs/bronze.py` owns both, instead of four copies of each:

- `read_all_partitions` reads the table prefix, not one dated partition, so a missed day is merged on the next run
- `load_bronze` **raises** when there is no Bronze data *and* the target table does not exist
- the date argument is gone from the four jobs and from the DAG, since nothing reads it now

### `recursiveFileLookup` is load-bearing, and this is worth knowing

The dated directories are plain `YYYY/MM/DD`, not Hive-style `key=value`. Without `recursiveFileLookup`, Spark treats them as partition directories, infers no schema, and raises `AnalysisException` on a prefix that plainly holds parquet — which the new code reads as "no data".

**The first version of this fix had that exact bug** and reported zero rows. It was caught by running it, not by reading it, which is why the guard asserts on the option.

## Verified on Docker, not reasoned about

Real MinIO, real Iceberg JDBC catalog in `postgres-dest`, two days of realistic orders parquet:

| Case | Result |
|---|---|
| single-day read (old behaviour) | 3 rows — one partition |
| prefix read (new behaviour) | **8 rows — both partitions** |
| no data + missing table | `RuntimeError`, naming what to check |
| no data + existing table | `None` — a genuine quiet run |
| full `transform_orders.py` run | 8 records read, `MERGE INTO` completed |

`scripts/ci/test_bronze_guard.py` holds the contract offline, including the `recursiveFileLookup` assertion.

| Check | Result |
|---|---|
| `ruff` / `bandit -ll` / `yamllint` | clean |
| `mypy` on `airflow/dags` | no issues, 3 files |
| `test_bronze_guard.py` | passes |
| `test_e2e_accounting.py` | passes |