### PR TITLE
Why the lake had three tables and not orders

### DIFF
--- a/airflow/dags/spark_transform_silver.py
+++ b/airflow/dags/spark_transform_silver.py
@@ -155,6 +155,7 @@ with DAG(
         bash_command=get_spark_submit_command('Customers-Bronze-to-Silver', '/opt/spark-jobs/transform_customers.py'),
         env=SPARK_SECRET_ENV,
         append_env=True,
+        trigger_rule='all_done',
     )
 
     transform_products = BashOperator(
@@ -162,6 +163,7 @@ with DAG(
         bash_command=get_spark_submit_command('Products-Bronze-to-Silver', '/opt/spark-jobs/transform_products.py'),
         env=SPARK_SECRET_ENV,
         append_env=True,
+        trigger_rule='all_done',
     )
 
     transform_order_items = BashOperator(
@@ -169,6 +171,7 @@ with DAG(
         bash_command=get_spark_submit_command('OrderItems-Bronze-to-Silver', '/opt/spark-jobs/transform_order_items.py'),
         env=SPARK_SECRET_ENV,
         append_env=True,
+        trigger_rule='all_done',
     )
 
     # Weekly Maintenance: Compaction & Z-Ordering (Essential for 1 Billion+ records)
@@ -196,9 +199,27 @@ with DAG(
         append_env=True,
         # Run only on Sundays to optimize storage after weekly activity
         execution_timeout=timedelta(hours=2),
+        trigger_rule='all_done',
     )
 
-    # Transformation happens sequentially to prevent Maven/Ivy cache download collisions
+    # Still sequential, but no longer all-or-nothing.
+    #
+    # The chain's original reason -- Maven/Ivy cache collisions between
+    # concurrent spark-submits -- went away when #133 baked the JARs into the
+    # image. It stays sequential for a different reason: a standalone Spark
+    # cluster gives an application every free core it can, and the workers here
+    # hold 2 cores and 2GB each, so four concurrent applications would leave
+    # some sitting in "Initial job has not accepted any resources" -- the same
+    # symptom #126 spent days on. One at a time is the safe shape.
+    #
+    # trigger_rule='all_done' is the part that changed. The default,
+    # all_success, meant a failure in the first task marked the other three
+    # upstream_failed, so one table's problem hid the state of every other
+    # table. #151 made that worse rather than better: it turned Bronze-missing
+    # from a silent skip into a real failure, which is correct in itself, but
+    # under all_success it would have taken three healthy tables down with the
+    # one broken one. Maintenance runs too, because expiring snapshots is what
+    # releases disk and a failed transform is no reason to stop reclaiming it.
     transform_orders >> transform_customers >> transform_products >> transform_order_items >> maintenance_task
 
     # Maintenance is logically downstream, but you can schedule it separately.

--- a/scripts/ci/test_bronze_guard.py
+++ b/scripts/ci/test_bronze_guard.py
@@ -30,6 +30,8 @@ class FakeCatalog:
 
     def tableExists(self, name):   # noqa: N802 - mirrors the PySpark API
         self.asked.append(name)
+        if isinstance(self._exists, Exception):
+            raise self._exists
         return self._exists
 
 
@@ -94,6 +96,24 @@ def main():
     )
     path = spark.read.option.return_value.parquet.call_args[0][0]
     assert path == "s3a://bronze/orders_source/", path
+
+    # 6. A catalog that cannot answer must read as "no table", not blow up.
+    #    An Iceberg JDBC catalog creates iceberg_tables lazily on first write,
+    #    so on a cluster where nothing has run yet tableExists raises
+    #    UncheckedSQLException instead of returning False. Letting that
+    #    propagate turned "the lakehouse is uninitialised" back into a Py4J
+    #    stack trace. Reproduced against a real fresh catalog before fixing.
+    boom = RuntimeError("UncheckedSQLException: relation iceberg_tables does not exist")
+    with mock.patch.object(bronze, "read_all_partitions", return_value=None):
+        try:
+            bronze.load_bronze(FakeSpark(table_exists=boom), "orders", "silver.lake.orders")
+        except RuntimeError as e:
+            assert "never been initialised" in str(e), (
+                "a catalog that raises should still produce the actionable "
+                f"message, got: {e}"
+            )
+        else:
+            raise AssertionError("a raising catalog must still raise on no data")
 
     print("bronze load contract: OK")
 

--- a/scripts/test_transactions.py
+++ b/scripts/test_transactions.py
@@ -314,8 +314,22 @@ def run_extract_pipeline():
             client.make_bucket("bronze")
         date_prefix = datetime.now().strftime("%Y/%m/%d")
         for i, fp in enumerate(chunk_files):
-            client.fput_object("bronze", f"orders/{date_prefix}/part-{i:05d}.parquet", fp)
-        ok(f"Uploaded {len(chunk_files)} parquet file(s) to MinIO s3://bronze/orders/{date_prefix}/")
+            # orders_source/, not orders/. The ingest DAG writes
+            # "<table>_source/YYYY/MM/DD/" and the Spark silver job reads that
+            # prefix, so parquet under "orders/" was invisible to Pipe 2.
+            #
+            # That alone would be a harmless naming slip. What made it a bug is
+            # the COPY below: it upserts these rows into raw.orders_source,
+            # which is where the ingest DAG reads its high-water mark
+            # (SELECT MAX(updated_at) FROM raw.orders_source). So every run of
+            # this test advanced the orders watermark while writing no Bronze
+            # the lakehouse could see, and the next real ingest found nothing
+            # new to extract. orders starved; the other three tables, which
+            # this test never loads into raw, kept flowing. That is exactly the
+            # state #144 reported -- silver.lake held customers, products and
+            # order_items, and never orders.
+            client.fput_object("bronze", f"orders_source/{date_prefix}/part-{i:05d}.parquet", fp)
+        ok(f"Uploaded {len(chunk_files)} parquet file(s) to MinIO s3://bronze/orders_source/{date_prefix}/")
     except Exception as e:
         fail("MinIO upload failed", str(e))
         print("  → Make sure MinIO is running and port-forwarded if using K8s")

--- a/spark/jobs/bronze.py
+++ b/spark/jobs/bronze.py
@@ -66,7 +66,7 @@ def load_bronze(spark, source_table, iceberg_table):
     count = df.count() if df is not None else 0
 
     if count == 0:
-        if not spark.catalog.tableExists(iceberg_table):
+        if not _table_exists(spark, iceberg_table):
             raise RuntimeError(
                 f"No Bronze data for '{source_table}' and {iceberg_table} does "
                 f"not exist, so the lakehouse has never been initialised. This "
@@ -82,3 +82,33 @@ def load_bronze(spark, source_table, iceberg_table):
 
     print(f"Loaded {count} records from Bronze")
     return df
+
+
+def _table_exists(spark, iceberg_table):
+    """tableExists, treating a catalog that cannot answer as "no".
+
+    An Iceberg JDBC catalog creates its `iceberg_tables` relation lazily, on
+    the first write. Until something has created a table, tableExists does not
+    return False -- it raises:
+
+        org.apache.iceberg.jdbc.UncheckedSQLException:
+            Failed to get table lake.orders from catalog silver
+        Caused by: PSQLException: relation "iceberg_tables" does not exist
+
+    Which is the exact condition this function is asked about on a cluster
+    where nothing has run yet, so letting it propagate turns "the lakehouse is
+    uninitialised" -- a state with a clear message to print -- back into an
+    opaque Py4J stack trace. An unanswerable catalog holds no tables, so the
+    answer is no.
+
+    Deliberately broad: the failures worth distinguishing here (bad JDBC
+    credentials, unreachable Postgres) surface immediately afterwards on the
+    write path with their own errors, and none of them are made worse by
+    having concluded the table is absent.
+    """
+    try:
+        return spark.catalog.tableExists(iceberg_table)
+    except Exception as e:  # noqa: BLE001 - see above
+        print(f"Could not query the catalog for {iceberg_table} "
+              f"({type(e).__name__}); treating it as absent.")
+        return False


### PR DESCRIPTION
Closes the `orders` gap reported in #144. Reproduced exactly on Docker against a fresh Iceberg JDBC catalog — **three separate faults**, only one of which was guessable from the code.

## 1. Root cause — the e2e test poisons the orders high-water mark

`test_transactions.py` step 3 wrote Bronze to `bronze/orders/`. The ingest DAG writes `<table>_source/YYYY/MM/DD/` and the Spark job reads that prefix, so **nothing the test uploaded was ever visible to Pipe 2.**

On its own that is a naming slip. What makes it a bug is the `COPY` on the next lines: it upserts those same rows into `raw.orders_source` — which is exactly where the ingest DAG reads its high-water mark (`SELECT MAX(updated_at) FROM raw.orders_source`).

So **every run of the test advanced the orders watermark while writing no Bronze the lakehouse could see.** The next real ingest extracted `WHERE updated_at > mark`, found nothing new, and wrote no Bronze. `orders` starved.

The other three tables are never loaded into `raw` by this test, so their watermarks stayed honest and their Bronze kept flowing. **That is why the lake held three of four.**

## 2. A regression from #151 — one table's failure took the other three

The four transforms are chained on the default `all_success`, so a failure in the first marks the rest `upstream_failed`.

#151 turned Bronze-missing from a silent skip into a real failure — correct in itself, but under `all_success` it would have taken three healthy tables down with the one broken one. They are now `all_done`.

Still sequential, and the comment explaining why is now accurate: not Maven cache collisions (#133 removed those by baking the JARs in) but that a standalone Spark cluster hands an application every free core, and these workers hold 2 each — four concurrent submits would sit in `Initial job has not accepted any resources`, the same symptom #126 spent days on. Maintenance is `all_done` too, since expiring snapshots is what releases disk and a failed transform is no reason to stop reclaiming it.

## 3. `tableExists` raises instead of returning False on a fresh catalog

An Iceberg JDBC catalog creates `iceberg_tables` lazily, on first write. On a cluster where nothing has run:

```
org.apache.iceberg.jdbc.UncheckedSQLException: Failed to get table lake.orders from catalog silver
Caused by: PSQLException: ERROR: relation "iceberg_tables" does not exist
```

That is the exact condition `load_bronze` asks about when nothing has run, so letting it propagate turned the clear "lakehouse has never been initialised" message back into a Py4J stack trace. An unanswerable catalog holds no tables.

The unit guard missed this because its fake returned a bool. It now covers a raising catalog, and I confirmed it **fails** when the `except` clause is narrowed.

## Verification

Real MinIO, real Iceberg JDBC catalog in its own database so nothing existing was touched:

| Scenario | Result |
|---|---|
| fresh catalog, Bronze for 3 tables, none for orders | |
| ├ `transform_orders` | exit 1, actionable message, no table |
| ├ `transform_customers` | exit 0, table created |
| ├ `transform_products` | exit 0, table created |
| ├ `transform_order_items` | exit 0, table created |
| └ catalog contents | `customers, order_items, products` — **#144's exact state** |
| same catalog, once Bronze exists at the prefix Spark reads | |
| ├ `transform_orders` | exit 0, table created |
| └ catalog contents | `customers, order_items, orders, products` |

Trigger rules confirmed through a real Airflow `DagBag`, not by reading the source — the three downstream transforms and maintenance all report `ALL_DONE`.

`ruff` / `bandit -ll` / `yamllint` / `mypy` / `bash -n` / both CI guards: clean.