### PR TITLE
Wire dbt-mcp to this project, without vendoring it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down restart logs seed dbt-run dbt-test register-connector ps help generate
+.PHONY: up down restart logs seed dbt-run dbt-test register-connector ps help generate mcp-dbt
 
 # Copy .env.example to .env if it doesn't exist yet
 .env:
@@ -52,6 +52,10 @@ register-connector:
 ## Regenerate pipeline artifacts from airflow/dags/config/pipelines.yml
 generate:
 	python3 scripts/generate_pipeline_assets.py
+
+## Check prerequisites for the dbt MCP server, print its client config
+mcp-dbt:
+	@bash scripts/mcp_dbt_config.sh
 
 ## Show this help
 help:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,54 @@ Debezium captures every insert/update/delete from the source WAL into Kafka, and
 
 A Next.js dashboard with an agentic analyst: it introspects the schemas of all three stores, decides which engine fits the question (warehouse, lakehouse via Trino, or the ClickHouse mirror), runs read-only SQL with automatic error-retry, and answers in plain language. Runs in demo mode without an API key; add an Anthropic API key to enable it, and set `DASHBOARD_AUTH_PASSWORD` to require a login.
 
+### dbt MCP Server
+
+The transformation layer is exposed over the **Model Context Protocol** by
+[dbt-mcp](https://docs.getdbt.com/docs/dbt-ai/about-mcp), dbt Labs' own server,
+so an assistant can *operate* dbt — run, build, test, compile, inspect lineage,
+generate model YAML — rather than only read the tables dbt produced.
+
+```bash
+make mcp-dbt      # checks prerequisites, prints the client config
+```
+
+It is intentionally not vendored. A copy lived in this repository until #70
+deleted 469 files that nothing consumed — no image build, no manifest, no
+import. It is a published package, so `uvx dbt-mcp` fetches it and the repo
+only owns the wiring.
+
+**Two flags matter more than the rest.** Semantic Layer, Discovery, Admin API
+and SQL tools all require a dbt Cloud account (`DBT_HOST`, `DBT_TOKEN`,
+`DBT_PROD_ENV_ID`…). Left enabled against dbt Core they are still advertised
+and fail on the first call: 49 tools of which roughly 30 are dead. Disabling
+them leaves **16 that all work**. `DISABLE_DBT_CODEGEN` is inverted — it
+defaults to true, so codegen has to be switched on.
+
+| Group | Works on dbt Core | Tools |
+|---|---|---|
+| dbt CLI | yes | `run`, `build`, `test`, `compile`, `parse`, `list`, `docs`, `clone`, `show` |
+| Codegen | yes, once enabled | `generate_model_yaml`, `generate_source`, `generate_staging_model` |
+| Dev lineage / docs | yes | `get_lineage_dev`, `get_node_details_dev`, `search_product_docs` |
+| Semantic Layer, Discovery, Admin API, SQL | **no — dbt Cloud** | `query_metrics`, `get_model_health`, `execute_sql`, `text_to_sql`, … |
+
+**Scope.** `show` runs SQL via `dbt show --inline` against the dbt target, so it
+reaches the **warehouse only**. The Iceberg lakehouse and the ClickHouse mirror
+are invisible to dbt, and therefore to dbt-mcp — for those, query Trino and
+ClickHouse directly, or use the AI dashboard, which talks to all three.
+
+**A working `dbt` is the one real prerequisite,** and `make mcp-dbt` checks it
+by running it rather than by finding it on `PATH`. An editable install from a
+source checkout can be present and still fail on import, in which case every
+dbt-mcp tool returns a Python traceback that reads like an MCP fault. If you
+need a clean one, pin it — an unpinned `pip install dbt-core` can resolve to a
+2.0 pre-release that ships no `dbt` console script at all:
+
+```bash
+python -m venv .venv-dbt
+.venv-dbt/bin/pip install 'dbt-core==1.9.*' 'dbt-postgres==1.9.*'
+DBT_PATH=$PWD/.venv-dbt/bin/dbt make mcp-dbt
+```
+
 ## Adding a Source Table
 
 Tables are defined once in [`airflow/dags/config/pipelines.yml`](airflow/dags/config/pipelines.yml) — the single source of truth. The ingestion DAG reads it directly; the ClickHouse mirror schema and Debezium connector are generated from it:

--- a/scripts/mcp_dbt_config.sh
+++ b/scripts/mcp_dbt_config.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# mcp_dbt_config.sh — check that dbt-mcp can run against this project, and
+# print the client configuration to paste into an MCP client.
+#
+# dbt-mcp is dbt Labs' MCP server. It exposes dbt itself -- run, build, test,
+# compile, model lineage, codegen -- over the Model Context Protocol, so an
+# assistant can operate the transformation layer rather than only read its
+# output tables.
+#
+# It is deliberately NOT vendored. A copy of it lived in this repository until
+# #70 removed 469 files that nothing consumed: no image build, no manifest, no
+# import. It is a published package; `uvx dbt-mcp` fetches it. This script
+# checks the prerequisites and prints the wiring, which is the part that is
+# specific to this repo.
+#
+# There is no "start the server" step on purpose. A stdio MCP server is
+# launched by its client, on demand -- running one from a shell just leaves a
+# process waiting on stdin.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'; NC='\033[0m'
+ok()   { echo -e "${GREEN}[OK]${NC}    $*"; }
+warn() { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+die()  { echo -e "${RED}[ERROR]${NC} $*"; exit 1; }
+
+# ─── uv / uvx ────────────────────────────────────────────────────────────────
+command -v uvx >/dev/null \
+  || die "uvx not found. Install uv: https://docs.astral.sh/uv/getting-started/installation/"
+ok "uvx found: $(command -v uvx)"
+
+# ─── a dbt that actually runs ────────────────────────────────────────────────
+# Checked by running it, not by existence. A dbt on PATH can be an editable
+# install from a source checkout with a missing dependency, in which case the
+# binary is present and every dbt-mcp tool fails at call time with a Python
+# traceback that looks like an MCP problem.
+DBT_BIN="${DBT_PATH:-$(command -v dbt || true)}"
+[ -n "$DBT_BIN" ] || die "No dbt on PATH. Install one:
+    python -m venv .venv-dbt
+    .venv-dbt/bin/pip install 'dbt-core==1.9.*' 'dbt-postgres==1.9.*'
+    DBT_PATH=\$PWD/.venv-dbt/bin/dbt make mcp-dbt
+  Pin the version: an unpinned 'pip install dbt-core' can resolve to a 2.0
+  pre-release that ships no 'dbt' console script at all."
+
+if ! DBT_VERSION="$("$DBT_BIN" --version 2>&1)"; then
+  die "dbt is present but does not run: $DBT_BIN
+$(echo "$DBT_VERSION" | tail -3)
+  If that traceback names a source checkout, this is an editable install with a
+  missing dependency. Use a clean virtualenv as above and pass DBT_PATH."
+fi
+ok "dbt runs: $DBT_BIN ($(echo "$DBT_VERSION" | grep -m1 -o 'installed: [0-9.]*' || echo 'version unknown'))"
+
+# ─── the dbt project ─────────────────────────────────────────────────────────
+[ -f "$REPO_ROOT/dbt/dbt_project.yml" ] || die "No dbt project at $REPO_ROOT/dbt"
+[ -f "$REPO_ROOT/dbt/profiles.yml" ]    || die "No profiles.yml at $REPO_ROOT/dbt"
+ok "dbt project and profile found in $REPO_ROOT/dbt"
+
+# ─── the warehouse the profile points at ─────────────────────────────────────
+# profiles.yml reads DEST_DB_* with docker-compose defaults, so the values
+# below are what the tools will actually connect with.
+DEST_HOST="${DEST_DB_HOST:-localhost}"
+DEST_PORT="${DEST_DB_PORT:-5433}"
+if command -v nc >/dev/null && ! nc -z "$DEST_HOST" "$DEST_PORT" 2>/dev/null; then
+  warn "Nothing listening on $DEST_HOST:$DEST_PORT — 'make up' first, or on"
+  warn "Kubernetes port-forward postgres-dest. Tools that compile will work;"
+  warn "'show' and 'test' need the warehouse."
+else
+  ok "warehouse reachable at $DEST_HOST:$DEST_PORT"
+fi
+
+# ─── the configuration ───────────────────────────────────────────────────────
+# The four DISABLE_* flags below are not optional tidying. Those tool groups
+# require a dbt Cloud account (DBT_HOST, DBT_TOKEN, DBT_PROD_ENV_ID and more);
+# left enabled against dbt Core, dbt-mcp still advertises roughly 30 tools that
+# fail the moment they are called. Disabling them takes the surface from 49
+# tools to 16 that all work.
+#
+# DISABLE_DBT_CODEGEN is inverted: it defaults to true, so codegen has to be
+# switched on rather than off.
+cat <<EOF
+
+────────────────────────────────────────────────────────────────────────────
+Claude Code (one line, paste as-is):
+
+  claude mcp add dbt -- env DBT_PROJECT_DIR=$REPO_ROOT/dbt DBT_PROFILES_DIR=$REPO_ROOT/dbt DBT_PATH=$DBT_BIN DEST_DB_HOST=$DEST_HOST DEST_DB_PORT=$DEST_PORT DISABLE_SEMANTIC_LAYER=true DISABLE_DISCOVERY=true DISABLE_ADMIN_API=true DISABLE_SQL=true DISABLE_DBT_CODEGEN=false uvx dbt-mcp
+
+Claude Desktop, or any client taking JSON:
+
+{
+  "mcpServers": {
+    "dbt": {
+      "command": "uvx",
+      "args": ["dbt-mcp"],
+      "env": {
+        "DBT_PROJECT_DIR": "$REPO_ROOT/dbt",
+        "DBT_PROFILES_DIR": "$REPO_ROOT/dbt",
+        "DBT_PATH": "$DBT_BIN",
+        "DEST_DB_HOST": "$DEST_HOST",
+        "DEST_DB_PORT": "$DEST_PORT",
+        "DISABLE_SEMANTIC_LAYER": "true",
+        "DISABLE_DISCOVERY": "true",
+        "DISABLE_ADMIN_API": "true",
+        "DISABLE_SQL": "true",
+        "DISABLE_DBT_CODEGEN": "false"
+      }
+    }
+  }
+}
+────────────────────────────────────────────────────────────────────────────
+
+16 tools: build clone compile docs generate_model_yaml generate_source
+generate_staging_model get_lineage_dev get_node_details_dev
+get_product_doc_pages list parse run search_product_docs show test
+
+'show' runs SQL through 'dbt show --inline' against the dbt target, so it
+reaches the warehouse only. The Iceberg lakehouse and the ClickHouse mirror
+are not visible to dbt and so not to dbt-mcp.
+EOF

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Compiled output of any tsc build in this package (e.g. tsconfig.mcp.json)
+dist/


### PR DESCRIPTION
The architecture slides show an MCP server on Pipe 1 and the repo hasn't had one since #70. That PR deleted a *vendored* copy of dbt Labs' dbt-mcp — 469 files, no image build, no manifest, nothing importing it. So what was missing was never the code; it was the wiring.

dbt-mcp is a published package. This adds `make mcp-dbt`, which checks the prerequisites and prints the client config.

```bash
make mcp-dbt
```

**No "start the server" step, deliberately.** A stdio MCP server is launched by its client on demand — running one from a shell just leaves a process waiting on stdin.

## Two things found by running it, not by reading the docs

**1. The flags are `DISABLE_*`, not `DBT_MCP_ENABLE_*`** — and getting that wrong is not inert. dbt-mcp starts anyway, warns about the missing `DBT_HOST`, and advertises **49 tools of which ~30 need a dbt Cloud account** and fail on first call. An assistant sees `query_metrics`, `get_model_health`, `trigger_job_run` and reaches for them.

With `DISABLE_SEMANTIC_LAYER`, `DISABLE_DISCOVERY`, `DISABLE_ADMIN_API`, `DISABLE_SQL` set: **16 tools, all working.**

`DISABLE_DBT_CODEGEN` is inverted — it defaults to `true`, so codegen has to be switched *on*.

**2. A `dbt` binary can be present and broken**, so the check runs it rather than locating it. This machine has an editable `dbt-core 1.12.0a1` install from a source checkout missing `metricflow_semantic_interfaces`: `command -v dbt` succeeds, `dbt --version` doesn't, and every dbt-mcp tool would return a Python traceback that reads like an MCP fault.

The error message says what that looks like and how to get a clean one — **pinned**, because an unpinned `pip install dbt-core` resolved here to a 2.0 pre-release shipping no `dbt` console script at all.

## Verified end to end against the running stack

| Check | Result |
|---|---|
| server starts via `uvx dbt-mcp` | yes |
| tools advertised | **16**, no Cloud-gated ones |
| `show` → `select count(*) from raw.orders_source` | **10000**, via `dbt show --inline` |
| `list` | all 12 models, 4 sources, dbt_expectations tests |
| preflight against the broken host dbt | fails with the actionable message |
| preflight against a clean dbt 1.9.11 | passes, prints config |
| `shellcheck` (default + `-S error`) | clean |
| `markdownlint`, `yamllint`, `ruff`, both CI guards | clean |
| `make help` alignment | intact |

## Scope, documented rather than implied

`show` goes through the dbt target, so dbt-mcp reaches the **warehouse only**. The Iceberg lakehouse and the ClickHouse mirror are invisible to dbt and therefore to dbt-mcp.

#153 covered those three stores and is **closed** in favour of keeping one MCP server. If the deck's slide 6 keeps an MCP box downstream of all three stores, that box has no implementation — it should move next to dbt, or #153 comes back.

Also adds `dist/` to `ui/.gitignore`: the ignore rule lived in #153, and without it a local `tsc` build is committable.