### PR TITLE
Trigger the silver DAG before asserting the lakehouse

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -157,9 +157,16 @@ bash scripts/test_e2e.sh
 
 This port-forwards the services, seeds 200 orders, runs the extract → MinIO →
 warehouse pipeline, fires live transactions (updates, cancellations, hard
-deletes), verifies the ClickHouse mirror caught every change, reads the Iceberg
-lakehouse through Trino, and checks the dbt marts are built and populated —
-one assertion per pipeline. Expected ending:
+deletes), verifies the ClickHouse mirror caught every change, **triggers
+`spark_transform_silver` and waits for it**, then reads the Iceberg lakehouse
+through Trino and checks the dbt marts — one assertion per pipeline.
+
+The Spark trigger matters. Without it the lakehouse check asserted a result
+nothing in the test causes: the silver DAG runs on its own hourly schedule, so
+on any cluster where `iceberg.lake.orders` did not already exist the check
+failed however healthy Pipe 2 was — reporting a broken pipeline when the truth
+was an unfinished one. Waiting can take a few minutes; `SILVER_DAG_TIMEOUT`
+(default 900s) bounds it.
 
 ```text
   ✓  Seeded 200 orders into postgres-source
@@ -170,12 +177,13 @@ one assertion per pipeline. Expected ending:
   ✓  Row count matches
   ✓  All 5 deleted orders are gone from the mirror
   ✓  All 10 cancellations reflected in the mirror
+  ✓  spark_transform_silver completed
   ✓  Iceberg tables present
   ✓  Lakehouse is readable and populated
   ✓  dbt marts present
   ✓  dbt marts populated
 
-  Total: 12 passed, 0 failed, 0 skipped
+  Total: 13 passed, 0 failed, 0 skipped
 
   All checks passed — all three pipelines verified end to end:
     Pipe 1  warehouse: dbt int/gold marts built and populated
@@ -183,16 +191,15 @@ one assertion per pipeline. Expected ending:
     Pipe 3  mirror:    counts, deletes and cancellations in ClickHouse
 ```
 
-A **skipped** check is not a passing one. If Trino is unreachable the lakehouse
-step reports `~` and the summary says the pipeline behind it is UNVERIFIED,
-rather than counting it green and claiming the stack is healthy — which is what
-it used to do, for as long as it never read the lakehouse at all (#149).
+A **skipped** check is not a passing one. If Trino is unreachable, or Airflow
+cannot be reached to trigger the silver DAG, those steps report `~` and the
+summary says the pipeline behind them is UNVERIFIED rather than counting them
+green — which is what it used to do, for as long as it never read the lakehouse
+at all (#149).
 
-The lakehouse and mart checks read what the DAGs produced, so they need at least
-one successful run of `ingest_source_to_bronze` and `spark_transform_silver`
-behind them. On a cluster deployed minutes ago they will fail honestly rather
-than pass vacuously; give the hourly schedules a run, or trigger both DAGs from
-the Airflow UI first.
+The mart check reads what the ingest DAG produced, so it still needs one
+successful run of `ingest_source_to_bronze` behind it. On a cluster deployed
+minutes ago it fails honestly rather than passing vacuously.
 
 ### Step 6 — Open the dashboards
 

--- a/scripts/ci/test_e2e_accounting.py
+++ b/scripts/ci/test_e2e_accounting.py
@@ -70,6 +70,42 @@ def main():
     assert "Some checks failed" in out, out
     assert "all three pipelines verified" not in out, out
 
+    # The silver-trigger step decides whether Pipe 2 gets a chance to run at
+    # all before it is asserted. Its branches need a cluster to exercise, so
+    # they are pinned here with fakes instead.
+    from unittest import mock
+
+    def outcome(cli, states):
+        """Run run_silver_pipeline with a canned CLI and state sequence."""
+        tt.results[:] = []
+        seq = list(states)
+        # DAG_WAIT_SECONDS is pinned short. Left at its 900s default the
+        # timeout case spins on real wall-clock -- sleep is mocked, time.time
+        # is not -- so this would only finish quickly if the caller happened
+        # to export SILVER_DAG_TIMEOUT. A check that needs the environment to
+        # terminate is not a check.
+        fake_proc = mock.Mock(returncode=0, stdout="", stderr="")
+        with (
+            mock.patch.object(tt, "DAG_WAIT_SECONDS", 1),
+            mock.patch.object(tt, "_airflow_cli", return_value=cli),
+            mock.patch.object(
+                tt, "_latest_run_state",
+                side_effect=lambda _: seq.pop(0) if seq else None,
+            ),
+            mock.patch.object(tt.subprocess, "run", return_value=fake_proc),
+            mock.patch.object(tt.time, "sleep"),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            tt.run_silver_pipeline()
+        return [r[0] for r in tt.results]
+
+    CLI = ["fake", "airflow"]
+    assert outcome(None, []) == ["SKIP"], "no Airflow reachable must skip, not pass"
+    assert outcome(CLI, ["queued", "success"]) == ["PASS"], "a successful run must pass"
+    assert outcome(CLI, ["running", "failed"]) == ["FAIL"], "a failed DAG must fail"
+    # Never settling is a failure, not a pass: Pipe 2 is unverified either way.
+    assert outcome(CLI, ["queued"] * 50) == ["FAIL"], "a run that never settles must fail"
+
     print("e2e result accounting: OK")
 
 

--- a/scripts/test_transactions.py
+++ b/scripts/test_transactions.py
@@ -36,8 +36,11 @@ Usage (Kubernetes — port-forward first):
 """
 
 import io
+import json
 import os
 import random
+import shutil
+import subprocess  # nosec B404 - fixed argv, no shell
 import sys
 import tempfile
 import time
@@ -522,6 +525,121 @@ def verify_clickhouse(txn, max_order_id):
         print(f"  {status:<15} {count:>6}")
 
 
+DAG_WAIT_SECONDS = int(os.environ.get("SILVER_DAG_TIMEOUT", "900"))
+
+
+def _airflow_cli():
+    """How to reach the Airflow CLI here, or None.
+
+    Checked in the order the platform is usually run: a Kubernetes cluster with
+    the etl namespace, then docker-compose. Returns the argv prefix that a dag
+    subcommand is appended to.
+    """
+    if shutil.which("kubectl"):
+        probe = subprocess.run(  # nosec B603 B607 - fixed argv, no shell
+            ["kubectl", "get", "deploy/airflow-scheduler", "-n", "etl"],
+            capture_output=True, text=True,
+        )
+        if probe.returncode == 0:
+            return ["kubectl", "exec", "-n", "etl", "deploy/airflow-scheduler",
+                    "--", "airflow"]
+    if shutil.which("docker"):
+        probe = subprocess.run(  # nosec B603 B607 - fixed argv, no shell
+            ["docker", "compose", "ps", "-q", "airflow-scheduler"],
+            capture_output=True, text=True,
+        )
+        if probe.returncode == 0 and probe.stdout.strip():
+            return ["docker", "compose", "exec", "-T", "airflow-scheduler",
+                    "airflow"]
+    return None
+
+
+def _latest_run_state(cli):
+    """State of the most recent spark_transform_silver run, or None."""
+    out = subprocess.run(  # nosec B603 - fixed argv, no shell
+        # dag_id is positional in Airflow 3; "-d" makes the CLI print help
+        # and exit 2, which read as "no runs" rather than as a broken command.
+        cli + ["dags", "list-runs", "spark_transform_silver",
+               "--no-backfill", "-o", "json"],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        return None
+    # Airflow writes its own log lines to stdout ahead of the JSON, and they
+    # contain brackets -- "[error    ] Could not configure StatsClient: [Errno
+    # -2]". Slicing from the first "[" parsed that instead of the payload and
+    # returned None every time, which the caller could not distinguish from
+    # "no runs yet": the wait loop would have polled until it timed out and
+    # then reported a healthy DAG as a failure.
+    start = out.stdout.find("[{")
+    if start == -1:
+        start = out.stdout.find("[]")
+    if start == -1:
+        return None
+    try:
+        runs = json.loads(out.stdout[start:])
+    except ValueError:
+        return None
+    return runs[0].get("state") if runs else None
+
+
+def run_silver_pipeline():
+    """Trigger spark_transform_silver and wait, before checking Trino.
+
+    Step 3 has just written Bronze. Without this, the lakehouse check asserted
+    a result nothing in the test causes: the Spark DAG runs on its own hourly
+    schedule, so on any cluster where iceberg.lake.orders did not already exist
+    it failed no matter how healthy Pipe 2 was. It reported a broken pipeline
+    when the truth was an unfinished one -- the inverse of #149 and just as
+    misleading.
+
+    Unreachable Airflow is a skip, never a pass.
+    """
+    step("STEP 6 — Run the Spark silver pipeline over the Bronze just written")
+
+    cli = _airflow_cli()
+    if cli is None:
+        skip(
+            "Could not reach Airflow to trigger spark_transform_silver",
+            "needs kubectl with the etl namespace, or a running docker-compose "
+            "airflow-scheduler. Trigger by hand and re-run: "
+            "airflow dags trigger spark_transform_silver",
+        )
+        return
+
+    before = _latest_run_state(cli)
+    trigger = subprocess.run(  # nosec B603 - fixed argv, no shell
+        cli + ["dags", "trigger", "spark_transform_silver"],
+        capture_output=True, text=True,
+    )
+    if trigger.returncode != 0:
+        fail("Could not trigger spark_transform_silver",
+             (trigger.stderr or trigger.stdout).strip()[:200])
+        return
+    print(f"  triggered; waiting up to {DAG_WAIT_SECONDS}s "
+          f"(SILVER_DAG_TIMEOUT to change)")
+
+    deadline = time.time() + DAG_WAIT_SECONDS
+    state = None
+    while time.time() < deadline:
+        time.sleep(15)
+        state = _latest_run_state(cli)
+        if state in ("success", "failed"):
+            break
+        print(f"    still {state or 'starting'}...")
+
+    if state == "success":
+        ok("spark_transform_silver completed", f"was {before or 'never run'} before")
+    elif state == "failed":
+        fail("spark_transform_silver failed",
+             "read the transform_orders task log -- 'Loaded N records from "
+             "Bronze' says whether Bronze reached it")
+    else:
+        fail(f"spark_transform_silver did not finish within {DAG_WAIT_SECONDS}s",
+             f"last state: {state or 'unknown'}")
+
+
+
 # ── Step 6: Lakehouse (Pipe 2) ────────────────────────────────────────────────
 def trino_query(sql):
     """Run one statement over Trino's REST protocol, following nextUri.
@@ -550,7 +668,7 @@ def trino_query(sql):
 
 
 def verify_lakehouse():
-    step("STEP 6 — Verify the Iceberg lakehouse (Pipe 2) through Trino")
+    step("STEP 7 — Verify the Iceberg lakehouse (Pipe 2) through Trino")
 
     if not TRINO_URL:
         skip(
@@ -607,9 +725,9 @@ def verify_lakehouse():
           "(batch lag plus merge-only semantics: the lake keeps deleted rows)")
 
 
-# ── Step 7: Warehouse marts (Pipe 1) ──────────────────────────────────────────
+# ── Step 8: Warehouse marts (Pipe 1) ──────────────────────────────────────────
 def verify_warehouse_marts():
-    step("STEP 7 — Verify the dbt marts (Pipe 1) are built and populated")
+    step("STEP 8 — Verify the dbt marts (Pipe 1) are built and populated")
 
     # Step 3 writes raw.orders_source itself, so finding rows there proves
     # nothing about the DAG. int/gold can only exist if the real dbt task
@@ -658,9 +776,9 @@ def verify_warehouse_marts():
         dest.close()
 
 
-# ── Step 8: Summary ───────────────────────────────────────────────────────────
+# ── Step 9: Summary ───────────────────────────────────────────────────────────
 def summary():
-    step("STEP 8 — Test Summary")
+    step("STEP 9 — Test Summary")
     passed = sum(1 for r in results if r[0] == "PASS")
     failed = sum(1 for r in results if r[0] == "FAIL")
     skipped = sum(1 for r in results if r[0] == "SKIP")
@@ -707,6 +825,7 @@ if __name__ == "__main__":
     txn = simulate_transactions()
 
     verify_clickhouse(txn, max_order_id=200)
+    run_silver_pipeline()
     verify_lakehouse()
     verify_warehouse_marts()
     summary()


### PR DESCRIPTION
#144: step 6 still fails after #152 — and it's the check that's wrong, not the cluster.

His run proves #152 worked:

```
✓ Uploaded 4 parquet file(s) to MinIO s3://bronze/orders_source/2026/08/23/
```

Right prefix. Bronze lands where Spark reads it.

## The bug

The lakehouse assertion fires immediately after that upload, and **nothing between the two runs Spark**. The test never triggers `spark_transform_silver`, and never runs the ingest DAG that would. So it asserts a result it does not cause.

The silver DAG is `@hourly`. On any cluster where `iceberg.lake.orders` didn't already exist, the check failed however healthy Pipe 2 was — reporting a *broken* pipeline when the truth was an *unfinished* one. The inverse of #149, and just as misleading.

## The fix

A new step triggers the DAG and waits, bounded by `SILVER_DAG_TIMEOUT` (default 900s). Airflow is reached through whichever CLI is present — `kubectl` into the `etl` namespace, else docker-compose. Neither available is a **skip with the manual command**, never a pass.

## Two defects found by running it, not reading the docs

**1. `dag_id` is positional in Airflow 3.** `dags list-runs -d <id>` prints help and exits 2 — which the caller read as "no runs" rather than "broken command."

**2. Airflow logs to stdout, ahead of the JSON, with brackets in them:**

```
[error    ] Could not configure StatsClient: [Errno -2] Name or service not known
```

Slicing from the first `[` parsed *that* instead of the payload and returned `None` every poll — indistinguishable from "no runs yet." The wait loop would have polled until timeout and then **reported a healthy DAG as a failure.** Now looks for `[{` or `[]`.

## Guards

The four branches need a cluster to exercise, so `scripts/ci/test_e2e_accounting.py` pins them with fakes:

| Case | Expected |
|---|---|
| Airflow unreachable | SKIP |
| run succeeds | PASS |
| run fails | FAIL |
| run never settles | FAIL |

Each confirmed to fail when its branch is regressed.

**That guard also needed fixing before it was worth anything.** Its timeout case spun on real wall-clock — `sleep` is mocked, `time.time` is not — so it only terminated promptly if the caller happened to export `SILVER_DAG_TIMEOUT`. It hung for 900s otherwise. `DAG_WAIT_SECONDS` is now pinned inside the test; it runs in **2.4s**.

## Verified

Trigger and poll exercised against a live docker-compose Airflow: triggered, polled `still queued...`, timed out cleanly at the bound. `ruff`, `bandit -ll`, `markdownlint`, both CI guards clean.