### PR TITLE
Stop writing empty Bronze parquet, and clear the ones already there

### DIFF
--- a/airflow/dags/ingest_source_to_bronze.py
+++ b/airflow/dags/ingest_source_to_bronze.py
@@ -186,6 +186,27 @@ def extract_and_load_table(table_name, **kwargs):
         log.info(f"Starting extraction for table: {table_name}")
         
         for chunk_idx, df_chunk in enumerate(pd.read_sql(query, source_engine, chunksize=chunk_size)):
+            # Skip empty chunks. pd.read_sql(chunksize=...) yields one empty
+            # DataFrame when the query matches nothing, which an incremental
+            # run with no new rows does constantly. Writing that produced a
+            # 0-row parquet whose every column is null-typed, and pyarrow has
+            # no dtype to infer from.
+            #
+            # Spark then reads such a file as INT for every column -- email
+            # INT, created_at INT -- and merging that with a real partition
+            # fails outright:
+            #   CANNOT_MERGE_INCOMPATIBLE_DATA_TYPE "INT" and "BIGINT"
+            #   Parquet column cannot be converted ... Expected: int, Found: INT64
+            # mergeSchema does not rescue it; the degenerate schema is the
+            # problem, not the merge.
+            #
+            # This was harmless while each Spark job read only its own day.
+            # Once #151 made them read every retained partition, one empty file
+            # anywhere under the prefix broke the whole table's transform. The
+            # file has no business existing either way: Bronze is a record of
+            # rows extracted, and there were none.
+            if df_chunk.empty:
+                continue
             out_path = os.path.join(tmpdirname, f'part-{chunk_idx:05d}.parquet')
             df_chunk.to_parquet(out_path, index=False, compression='snappy', coerce_timestamps='us', allow_truncated_timestamps=True)
             total_rows += len(df_chunk)
@@ -334,6 +355,16 @@ def prune_bronze(**kwargs):
         if written < cutoff:
             stale.append(key)
 
+    empties = _empty_parquet_keys(s3_hook, bucket, set(keys) - set(stale))
+    if empties:
+        # 0-row parquet written before the guard in extract_and_load_table.
+        # Every column in one is null-typed, which Spark reads as INT, so a
+        # single leftover breaks the transform for that whole table until
+        # retention ages it out -- up to BRONZE_RETENTION_DAYS of a broken
+        # lakehouse. Cheaper to remove them than to wait.
+        s3_hook.delete_objects(bucket=bucket, keys=empties)
+        log.info(f"Removed {len(empties)} empty Bronze object(s)")
+
     if not stale:
         log.info(f"No Bronze objects older than {retention_days} days")
         return
@@ -341,6 +372,28 @@ def prune_bronze(**kwargs):
     s3_hook.delete_objects(bucket=bucket, keys=stale)
     log.info(f"Pruned {len(stale)} Bronze objects older than "
              f"{retention_days} days (before {cutoff:%Y-%m-%d})")
+
+
+def _empty_parquet_keys(s3_hook, bucket, keys):
+    """Keys under `bucket` whose parquet holds no rows.
+
+    Reads footers only -- these files are a few KB -- and treats anything it
+    cannot parse as "leave alone", since deleting on a read error would turn a
+    transient S3 problem into data loss.
+    """
+    import pyarrow.parquet as pq
+
+    empty = []
+    for key in keys:
+        if not key.endswith('.parquet'):
+            continue
+        try:
+            body = s3_hook.get_key(key, bucket_name=bucket).get()['Body'].read()
+            if pq.ParquetFile(io.BytesIO(body)).metadata.num_rows == 0:
+                empty.append(key)
+        except Exception as e:
+            log.warning(f"Could not inspect {key}, leaving it: {e}")
+    return empty
 
 
 with dag:


### PR DESCRIPTION
Found by running the stack end to end on Docker — not by reading code. `transform_customers` failed with:

```
Parquet column cannot be converted in file s3a://bronze/customers_source/2026/08/24/part-...parquet
Column: [customer_id], Expected: int, Found: INT64
```

That reads like type drift. It isn't. Three files sat under the prefix:

```
2026/08/23/part-...T100000   customer_id: null    rows: 0
2026/08/24/part-...T170000   customer_id: int64   rows: 100
2026/08/24/part-...T183222   customer_id: null    rows: 0
```

## Cause

`pd.read_sql(chunksize=...)` yields **one empty DataFrame** when the query matches nothing — which an incremental run with no new rows does constantly. That got written as a 0-row parquet, and pyarrow has no dtype to infer, so **every column lands null-typed**. The `if not chunk_files` guard never fired, because a file *had* been written.

Spark reads a null-typed parquet column as `INT` — `email: INT`, `created_at: INT` — which cannot merge with the real schema. `mergeSchema` doesn't rescue it, it fails differently:

```
CANNOT_MERGE_INCOMPATIBLE_DATA_TYPE "INT" and "BIGINT"
```

Both verified against the running stack.

## Why now

Latent for as long as the jobs read one day at a time — a run whose own day held only the empty file read a 0-row frame and moved on.

**#151 made it fatal** by reading every retained partition, so one empty file anywhere under a prefix breaks that table's transform entirely. `transform_orders` escaped it; `customers`, `products` and `order_items` did not.

## Two changes

The ingest fix alone leaves existing clusters broken until retention ages the files out — up to `BRONZE_RETENTION_DAYS` of dead lakehouse. So:

- **`extract_and_load_table` skips empty chunks.** Bronze records rows extracted, and there were none.
- **`prune_bronze` deletes 0-row objects**, reading footers only and leaving anything it can't parse alone — deleting on a read error would turn a transient S3 problem into data loss.

## Verified in one real DAG run on compose

| | |
|---|---|
| `ingest_customers` | success, wrote **no file at all** |
| `prune_bronze` | `Removed 8 empty Bronze objects` |
| `transform_customers` | **100 records loaded and merged** — had failed 4× before |
| `iceberg.lake.orders` | 10000 rows via Trino |
| `mirror.orders_current` | 10000 rows |

A full `test_transactions.py` run is in flight and I'll post the result.