### PR TITLE
Wait for pending silver runs instead of queueing another

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -168,6 +168,14 @@ failed however healthy Pipe 2 was — reporting a broken pipeline when the truth
 was an unfinished one. Waiting can take a few minutes; `SILVER_DAG_TIMEOUT`
 (default 900s) bounds it.
 
+If runs are already queued or running, the step waits for those instead of
+triggering another. The DAG is `max_active_runs=1`, so a new run joins the back
+of the queue and the step would then block on the whole backlog — which is how
+a healthy cluster reported `did not finish within 900s (last state: queued)`.
+A pending run picks up the Bronze just written anyway, since the Spark jobs read
+every retained partition. If the queue is deep, raise `SILVER_DAG_TIMEOUT` or
+clear old runs in the Airflow UI.
+
 ```text
   ✓  Seeded 200 orders into postgres-source
   ✓  Validation passed

--- a/scripts/ci/test_e2e_accounting.py
+++ b/scripts/ci/test_e2e_accounting.py
@@ -89,8 +89,8 @@ def main():
             mock.patch.object(tt, "DAG_WAIT_SECONDS", 1),
             mock.patch.object(tt, "_airflow_cli", return_value=cli),
             mock.patch.object(
-                tt, "_latest_run_state",
-                side_effect=lambda _: seq.pop(0) if seq else None,
+                tt, "_run_states",
+                side_effect=lambda _: seq.pop(0) if seq else [],
             ),
             mock.patch.object(tt.subprocess, "run", return_value=fake_proc),
             mock.patch.object(tt.time, "sleep"),
@@ -101,10 +101,27 @@ def main():
 
     CLI = ["fake", "airflow"]
     assert outcome(None, []) == ["SKIP"], "no Airflow reachable must skip, not pass"
-    assert outcome(CLI, ["queued", "success"]) == ["PASS"], "a successful run must pass"
-    assert outcome(CLI, ["running", "failed"]) == ["FAIL"], "a failed DAG must fail"
-    # Never settling is a failure, not a pass: Pipe 2 is unverified either way.
-    assert outcome(CLI, ["queued"] * 50) == ["FAIL"], "a run that never settles must fail"
+    assert outcome(CLI, [[], ["success"]]) == ["PASS"], "a drained queue ending in success must pass"
+    assert outcome(CLI, [[], ["failed"]]) == ["FAIL"], "a failed DAG must fail"
+    # Never draining is a failure, not a pass: Pipe 2 is unverified either way.
+    assert outcome(CLI, [["queued"]] * 50) == ["FAIL"], "a queue that never drains must fail"
+
+    # The reason #155 timed out on a healthy cluster: it triggered a run behind
+    # an existing backlog and then waited for that run, so the step blocked on
+    # the whole queue. With work already pending it must wait, not pile on.
+    tt.results[:] = []
+    seq = [["queued", "running"], ["success", "success"]]
+    with (
+        mock.patch.object(tt, "DAG_WAIT_SECONDS", 1),
+        mock.patch.object(tt, "_airflow_cli", return_value=CLI),
+        mock.patch.object(tt, "_run_states", side_effect=lambda _: seq.pop(0) if seq else []),
+        mock.patch.object(tt.subprocess, "run") as spawned,
+        mock.patch.object(tt.time, "sleep"),
+        contextlib.redirect_stdout(io.StringIO()),
+    ):
+        tt.run_silver_pipeline()
+    assert spawned.call_count == 0, "must not trigger when a run is already pending"
+    assert [r[0] for r in tt.results] == ["PASS"], tt.results
 
     print("e2e result accounting: OK")
 

--- a/scripts/test_transactions.py
+++ b/scripts/test_transactions.py
@@ -554,8 +554,8 @@ def _airflow_cli():
     return None
 
 
-def _latest_run_state(cli):
-    """State of the most recent spark_transform_silver run, or None."""
+def _run_states(cli):
+    """Every spark_transform_silver run state, newest first, or None."""
     out = subprocess.run(  # nosec B603 - fixed argv, no shell
         # dag_id is positional in Airflow 3; "-d" makes the CLI print help
         # and exit 2, which read as "no runs" rather than as a broken command.
@@ -580,7 +580,7 @@ def _latest_run_state(cli):
         runs = json.loads(out.stdout[start:])
     except ValueError:
         return None
-    return runs[0].get("state") if runs else None
+    return [r.get("state") for r in runs]
 
 
 def run_silver_pipeline():
@@ -607,36 +607,57 @@ def run_silver_pipeline():
         )
         return
 
-    before = _latest_run_state(cli)
-    trigger = subprocess.run(  # nosec B603 - fixed argv, no shell
-        cli + ["dags", "trigger", "spark_transform_silver"],
-        capture_output=True, text=True,
-    )
-    if trigger.returncode != 0:
-        fail("Could not trigger spark_transform_silver",
-             (trigger.stderr or trigger.stdout).strip()[:200])
-        return
-    print(f"  triggered; waiting up to {DAG_WAIT_SECONDS}s "
+    # Do not add to the queue when something is already pending. The DAG runs
+    # max_active_runs=1, so a new run goes to the BACK of whatever is waiting
+    # and this step then blocks on the entire backlog -- which is how a healthy
+    # cluster reported "did not finish within 900s (last state: queued)". A run
+    # already queued or running will pick up the Bronze just written anyway,
+    # because the jobs read every retained partition, so waiting for it is both
+    # faster and a truer test than triggering another.
+    pending = [st for st in (_run_states(cli) or []) if st in ("queued", "running")]
+    if pending:
+        print(f"  {len(pending)} run(s) already queued or running; waiting for "
+              f"those rather than adding another")
+    else:
+        trigger = subprocess.run(  # nosec B603 - fixed argv, no shell
+            cli + ["dags", "trigger", "spark_transform_silver"],
+            capture_output=True, text=True,
+        )
+        if trigger.returncode != 0:
+            fail("Could not trigger spark_transform_silver",
+                 (trigger.stderr or trigger.stdout).strip()[:200])
+            return
+        print("  triggered")
+    print(f"  waiting up to {DAG_WAIT_SECONDS}s for the queue to drain "
           f"(SILVER_DAG_TIMEOUT to change)")
 
+    # Done when nothing is queued or running any more. Watching one run's id
+    # would still have meant waiting out the backlog ahead of it.
     deadline = time.time() + DAG_WAIT_SECONDS
-    state = None
+    states = []
     while time.time() < deadline:
         time.sleep(15)
-        state = _latest_run_state(cli)
-        if state in ("success", "failed"):
+        states = _run_states(cli) or []
+        outstanding = [st for st in states if st in ("queued", "running")]
+        if not outstanding:
             break
-        print(f"    still {state or 'starting'}...")
+        print(f"    {len(outstanding)} outstanding ({', '.join(sorted(set(outstanding)))})...")
 
-    if state == "success":
-        ok("spark_transform_silver completed", f"was {before or 'never run'} before")
-    elif state == "failed":
+    outstanding = [st for st in states if st in ("queued", "running")]
+    if outstanding:
+        fail(f"spark_transform_silver still busy after {DAG_WAIT_SECONDS}s",
+             f"{len(outstanding)} run(s) {', '.join(sorted(set(outstanding)))}. A "
+             f"backlog drains one run at a time (max_active_runs=1); raise "
+             f"SILVER_DAG_TIMEOUT, or clear old runs in the Airflow UI")
+    elif states and states[0] == "success":
+        ok("spark_transform_silver completed")
+    elif states and states[0] == "failed":
         fail("spark_transform_silver failed",
              "read the transform_orders task log -- 'Loaded N records from "
              "Bronze' says whether Bronze reached it")
     else:
-        fail(f"spark_transform_silver did not finish within {DAG_WAIT_SECONDS}s",
-             f"last state: {state or 'unknown'}")
+        fail("Could not read spark_transform_silver run state",
+             f"last seen: {states[:1] or 'nothing'}")
 
 
 


### PR DESCRIPTION
#144: on a healthy cluster the new step reported

```
✗  spark_transform_silver did not finish within 900s  (last state: queued)
```

Right that nothing finished. Wrong about why.

## Cause

`spark_transform_silver` is `max_active_runs=1`. The step triggered a run **unconditionally**, so with anything already pending the new one joined the **back of the queue** — and then the step blocked on the entire backlog rather than on the work it cared about. Each run takes minutes; a few queued ahead is more than 900s.

Piling on was never necessary. A run already queued or running **picks up the Bronze just written anyway**, because #151 made the jobs read every retained partition rather than one day's. So waiting for it is both faster and a truer test of what the platform does unattended.

## Fix

- Trigger **only when nothing is pending**
- Wait for the **queue to drain**, not for one run id — watching a specific run still means waiting out everything ahead of it
- The timeout message now says how many runs are outstanding and that a backlog drains one at a time, so the next person sees a queue rather than a broken DAG

## Guard

Gains the case that caused this: **with a run already pending, nothing may be spawned.**

```python
assert spawned.call_count == 0, "must not trigger when a run is already pending"
```

Confirmed it fails (exit 1) when the pending check is bypassed.

`ruff`, `mypy`, `markdownlint`, both CI guards clean.

## Note on the other half

Raghu's run in #144 was on `8c6076e` — #155 only. He didn't have #156 (empty Bronze parquet) yet, so even with this fix he needs to pull again before the lakehouse can build.