### PR TITLE
Fail wedged DAG runs instead of blocking the pipeline forever

### DIFF
--- a/airflow/dags/ingest_source_to_bronze.py
+++ b/airflow/dags/ingest_source_to_bronze.py
@@ -115,6 +115,19 @@ dag = DAG(
     # Never let a slow run overlap the next one: concurrent runs would race
     # on the same raw tables and high-water mark.
     max_active_runs=1,
+    # A run that never reaches a terminal state holds the single active slot
+    # for good. #144 hit exactly that: a scheduled run from 2026-08-15 sat in
+    # "running" for nine days after its task hit
+    #   state mismatch ... Executor reported ... finished with state failed,
+    #   but the task instance's state attribute is queued
+    # so every later run stayed queued behind it and the lakehouse silently
+    # stopped being built. Nothing surfaced it, because a queued run is not an
+    # error -- there is simply no error anywhere to find.
+    #
+    # dagrun_timeout makes the scheduler fail such a run instead of waiting on
+    # it forever. Two hours is well clear of a real run (minutes) while still
+    # clearing a zombie the same day.
+    dagrun_timeout=timedelta(hours=2),
     tags=['etl', 'bronze', 'multi-table'],
 )
 

--- a/airflow/dags/spark_transform_silver.py
+++ b/airflow/dags/spark_transform_silver.py
@@ -45,6 +45,19 @@ with DAG(
     # Spark jobs are long-running; overlapping runs would MERGE into the same
     # Iceberg tables concurrently.
     max_active_runs=1,
+    # A run that never reaches a terminal state holds the single active slot
+    # for good. #144 hit exactly that: a scheduled run from 2026-08-15 sat in
+    # "running" for nine days after its task hit
+    #   state mismatch ... Executor reported ... finished with state failed,
+    #   but the task instance's state attribute is queued
+    # so every later run stayed queued behind it and the lakehouse silently
+    # stopped being built. Nothing surfaced it, because a queued run is not an
+    # error -- there is simply no error anywhere to find.
+    #
+    # dagrun_timeout makes the scheduler fail such a run instead of waiting on
+    # it forever. Two hours is well clear of a real run (minutes) while still
+    # clearing a zombie the same day.
+    dagrun_timeout=timedelta(hours=2),
     tags=['spark', 'iceberg', 'silver', 'scalability', 'compaction'],
 ) as dag:
 

--- a/scripts/ci/test_e2e_accounting.py
+++ b/scripts/ci/test_e2e_accounting.py
@@ -89,7 +89,7 @@ def main():
             mock.patch.object(tt, "DAG_WAIT_SECONDS", 1),
             mock.patch.object(tt, "_airflow_cli", return_value=cli),
             mock.patch.object(
-                tt, "_run_states",
+                tt, "_runs",
                 side_effect=lambda _: seq.pop(0) if seq else [],
             ),
             mock.patch.object(tt.subprocess, "run", return_value=fake_proc),
@@ -101,20 +101,21 @@ def main():
 
     CLI = ["fake", "airflow"]
     assert outcome(None, []) == ["SKIP"], "no Airflow reachable must skip, not pass"
-    assert outcome(CLI, [[], ["success"]]) == ["PASS"], "a drained queue ending in success must pass"
-    assert outcome(CLI, [[], ["failed"]]) == ["FAIL"], "a failed DAG must fail"
+    assert outcome(CLI, [[], [{"state": "success"}]]) == ["PASS"], "a drained queue ending in success must pass"
+    assert outcome(CLI, [[], [{"state": "failed"}]]) == ["FAIL"], "a failed DAG must fail"
     # Never draining is a failure, not a pass: Pipe 2 is unverified either way.
-    assert outcome(CLI, [["queued"]] * 50) == ["FAIL"], "a queue that never drains must fail"
+    assert outcome(CLI, [[{"state": "queued"}]] * 50) == ["FAIL"], "a queue that never drains must fail"
 
     # The reason #155 timed out on a healthy cluster: it triggered a run behind
     # an existing backlog and then waited for that run, so the step blocked on
     # the whole queue. With work already pending it must wait, not pile on.
     tt.results[:] = []
-    seq = [["queued", "running"], ["success", "success"]]
+    seq = [[{"state": "queued"}, {"state": "running"}],
+           [{"state": "success"}, {"state": "success"}]]
     with (
         mock.patch.object(tt, "DAG_WAIT_SECONDS", 1),
         mock.patch.object(tt, "_airflow_cli", return_value=CLI),
-        mock.patch.object(tt, "_run_states", side_effect=lambda _: seq.pop(0) if seq else []),
+        mock.patch.object(tt, "_runs", side_effect=lambda _: seq.pop(0) if seq else []),
         mock.patch.object(tt.subprocess, "run") as spawned,
         mock.patch.object(tt.time, "sleep"),
         contextlib.redirect_stdout(io.StringIO()),
@@ -122,6 +123,26 @@ def main():
         tt.run_silver_pipeline()
     assert spawned.call_count == 0, "must not trigger when a run is already pending"
     assert [r[0] for r in tt.results] == ["PASS"], tt.results
+
+    # A wedged run and a deep queue look identical from outside -- both report
+    # "queued" forever -- but the remedies are opposite. The message has to
+    # tell them apart, which is the round trip #144 spent.
+    day_old = [{"state": "running", "start_date": "2026-08-15T00:00:00+00:00"},
+               {"state": "queued", "start_date": ""}]
+    detail = tt._stuck_detail(day_old)
+    assert "stuck run" in detail, detail
+    assert "Mark it failed" in detail, detail
+    assert "raise SILVER_DAG_TIMEOUT" not in detail, (
+        "a nine-day-old run is not a backlog; telling someone to wait longer "
+        f"is the wrong remedy: {detail}"
+    )
+
+    from datetime import datetime, timezone
+    fresh = [{"state": "queued",
+              "start_date": datetime.now(timezone.utc).isoformat()}]
+    detail = tt._stuck_detail(fresh)
+    assert "backlog drains" in detail, detail
+    assert "stuck run" not in detail, detail
 
     print("e2e result accounting: OK")
 

--- a/scripts/test_transactions.py
+++ b/scripts/test_transactions.py
@@ -554,8 +554,8 @@ def _airflow_cli():
     return None
 
 
-def _run_states(cli):
-    """Every spark_transform_silver run state, newest first, or None."""
+def _runs(cli):
+    """Every spark_transform_silver run, newest first, or None."""
     out = subprocess.run(  # nosec B603 - fixed argv, no shell
         # dag_id is positional in Airflow 3; "-d" makes the CLI print help
         # and exit 2, which read as "no runs" rather than as a broken command.
@@ -580,7 +580,7 @@ def _run_states(cli):
         runs = json.loads(out.stdout[start:])
     except ValueError:
         return None
-    return [r.get("state") for r in runs]
+    return runs
 
 
 def run_silver_pipeline():
@@ -614,7 +614,7 @@ def run_silver_pipeline():
     # already queued or running will pick up the Bronze just written anyway,
     # because the jobs read every retained partition, so waiting for it is both
     # faster and a truer test than triggering another.
-    pending = [st for st in (_run_states(cli) or []) if st in ("queued", "running")]
+    pending = [r for r in (_runs(cli) or []) if r.get("state") in ("queued", "running")]
     if pending:
         print(f"  {len(pending)} run(s) already queued or running; waiting for "
               f"those rather than adding another")
@@ -634,30 +634,62 @@ def run_silver_pipeline():
     # Done when nothing is queued or running any more. Watching one run's id
     # would still have meant waiting out the backlog ahead of it.
     deadline = time.time() + DAG_WAIT_SECONDS
-    states = []
+    runs = []
     while time.time() < deadline:
         time.sleep(15)
-        states = _run_states(cli) or []
-        outstanding = [st for st in states if st in ("queued", "running")]
+        runs = _runs(cli) or []
+        outstanding = [r for r in runs if r.get("state") in ("queued", "running")]
         if not outstanding:
             break
-        print(f"    {len(outstanding)} outstanding ({', '.join(sorted(set(outstanding)))})...")
+        print(f"    {len(outstanding)} outstanding "
+              f"({', '.join(sorted({r['state'] for r in outstanding}))})...")
 
-    outstanding = [st for st in states if st in ("queued", "running")]
+    outstanding = [r for r in runs if r.get("state") in ("queued", "running")]
     if outstanding:
         fail(f"spark_transform_silver still busy after {DAG_WAIT_SECONDS}s",
-             f"{len(outstanding)} run(s) {', '.join(sorted(set(outstanding)))}. A "
-             f"backlog drains one run at a time (max_active_runs=1); raise "
-             f"SILVER_DAG_TIMEOUT, or clear old runs in the Airflow UI")
-    elif states and states[0] == "success":
+             _stuck_detail(outstanding))
+    elif runs and runs[0].get("state") == "success":
         ok("spark_transform_silver completed")
-    elif states and states[0] == "failed":
+    elif runs and runs[0].get("state") == "failed":
         fail("spark_transform_silver failed",
              "read the transform_orders task log -- 'Loaded N records from "
              "Bronze' says whether Bronze reached it")
     else:
         fail("Could not read spark_transform_silver run state",
-             f"last seen: {states[:1] or 'nothing'}")
+             f"last seen: {runs[:1] or 'nothing'}")
+
+
+def _stuck_detail(outstanding):
+    """Say whether the queue is merely deep or wedged behind a zombie run.
+
+    A backlog and a run stuck in "running" since last week look identical from
+    the outside -- both report "queued" forever -- but the remedies are
+    opposite: wait longer, versus go and kill something. #144 spent a round
+    trip on that, because the message only offered "raise the timeout" while
+    the real blocker was a run that had been running for nine days.
+    """
+    kinds = ', '.join(sorted({r['state'] for r in outstanding}))
+    oldest = min((r for r in outstanding if r.get('start_date')),
+                 key=lambda r: r['start_date'], default=None)
+    detail = f"{len(outstanding)} run(s) {kinds}. "
+    if oldest:
+        started = oldest['start_date'][:19]
+        age_days = 0
+        try:
+            started_at = datetime.fromisoformat(oldest['start_date'].replace('Z', '+00:00'))
+            age_days = (datetime.now(started_at.tzinfo) - started_at).days
+        except ValueError:
+            pass
+        if age_days >= 1:
+            return (detail + f"The oldest has been running since {started} "
+                    f"({age_days} day(s)) -- that is a stuck run holding the "
+                    f"only active slot (max_active_runs=1), not a backlog. "
+                    f"Mark it failed in the Airflow UI; deleting it often "
+                    f"errors while it is still active.")
+        detail += f"Oldest started {started}. "
+    return (detail + "A backlog drains one run at a time "
+            "(max_active_runs=1); raise SILVER_DAG_TIMEOUT, or clear old runs "
+            "in the Airflow UI.")
 
 
 


### PR DESCRIPTION
#144's queue never drained, and the audit log says why:

```
state mismatch ... Executor KubernetesExecutor reported that the task instance
spark_transform_silver.transform_customers scheduled__2026-08-15T00:00:00
finished with state failed, but the task instance's state attribute is queued.
Pod failed because of None
```

That run then sat in `running` for **nine days**.

## Why it matters more than it looks

`spark_transform_silver` is `max_active_runs=1`, so that one wedged run held the only slot and **every later run stayed queued behind it**. The lakehouse quietly stopped being built on 15 August.

Nothing reported a fault, because *a queued run is not an error* — there was no error anywhere to find. And deleting the run through the UI fails while it's still active, which is how it survived that long.

That also reframes the whole thread: the empty-Bronze bug (#156) was real, but this is why nothing has run since.

## Fix

**`dagrun_timeout=2h` on both scheduled DAGs.** The scheduler fails such a run instead of waiting on it. Two hours is well clear of a real run (minutes) and still clears a zombie the same day.

## The message was also wrong

A deep backlog and a run wedged since last week look identical from outside — both report `queued` forever — but the remedies are **opposite**: wait longer, versus go and kill something.

The timeout detail offered only "raise SILVER_DAG_TIMEOUT", which was exactly the wrong advice for a nine-day-old run, and cost a round trip. It now reports the oldest outstanding run's start time, and when that's a day or more old says plainly:

> The oldest has been running since 2026-08-15T00:00:00 (9 day(s)) — that is a stuck run holding the only active slot (max_active_runs=1), not a backlog. Mark it failed in the Airflow UI; deleting it often errors while it is still active.

## Guards

| Case | Must |
|---|---|
| day-old outstanding run | say "stuck run", say "Mark it failed", **not** suggest raising the timeout |
| fresh outstanding run | still read as a backlog |

Confirmed the guard fails when the age check is removed.

`ruff`, `bandit -ll`, `mypy`, both CI guards clean.