### PR TITLE
Dedupe Bronze by primary key before MERGE

### DIFF
--- a/scripts/ci/test_bronze_guard.py
+++ b/scripts/ci/test_bronze_guard.py
@@ -55,7 +55,7 @@ def main():
     #    This is the case that used to exit 0 and take Pipe 2 down silently.
     with mock.patch.object(bronze, "read_all_partitions", return_value=None):
         try:
-            bronze.load_bronze(FakeSpark(table_exists=False), "orders", "silver.lake.orders")
+            bronze.load_bronze(FakeSpark(table_exists=False), "orders", "silver.lake.orders", "order_id")
         except RuntimeError as e:
             assert "never been initialised" in str(e), str(e)
             assert "silver.lake.orders" in str(e), str(e)
@@ -64,9 +64,10 @@ def main():
             raise AssertionError("no data and no table must raise, not return")
 
     # 2. An empty frame is the same condition as no frame at all.
-    with mock.patch.object(bronze, "read_all_partitions", return_value=FakeDF(0)):
+    with (mock.patch.object(bronze, "read_all_partitions", return_value=FakeDF(0)),
+          mock.patch.object(bronze, "_latest_per_key", side_effect=lambda d, k: d)):
         try:
-            bronze.load_bronze(FakeSpark(table_exists=False), "orders", "silver.lake.orders")
+            bronze.load_bronze(FakeSpark(table_exists=False), "orders", "silver.lake.orders", "order_id")
         except RuntimeError:
             pass
         else:
@@ -75,14 +76,15 @@ def main():
     # 3. No Bronze data but the table exists: a genuinely quiet run.
     with mock.patch.object(bronze, "read_all_partitions", return_value=None):
         assert bronze.load_bronze(
-            FakeSpark(table_exists=True), "orders", "silver.lake.orders"
+            FakeSpark(table_exists=True), "orders", "silver.lake.orders", "order_id"
         ) is None
 
     # 4. Rows present: hand them back, and do not consult the catalog at all.
     df = FakeDF(42)
     spark = FakeSpark(table_exists=False)
-    with mock.patch.object(bronze, "read_all_partitions", return_value=df):
-        assert bronze.load_bronze(spark, "orders", "silver.lake.orders") is df
+    with (mock.patch.object(bronze, "read_all_partitions", return_value=df),
+          mock.patch.object(bronze, "_latest_per_key", side_effect=lambda d, k: d)):
+        assert bronze.load_bronze(spark, "orders", "silver.lake.orders", "order_id") is df
     assert spark.catalog.asked == [], "the happy path should not need tableExists"
 
     # 5. The reader must target the table prefix, not one dated partition.
@@ -106,7 +108,7 @@ def main():
     boom = RuntimeError("UncheckedSQLException: relation iceberg_tables does not exist")
     with mock.patch.object(bronze, "read_all_partitions", return_value=None):
         try:
-            bronze.load_bronze(FakeSpark(table_exists=boom), "orders", "silver.lake.orders")
+            bronze.load_bronze(FakeSpark(table_exists=boom), "orders", "silver.lake.orders", "order_id")
         except RuntimeError as e:
             assert "never been initialised" in str(e), (
                 "a catalog that raises should still produce the actionable "
@@ -114,6 +116,54 @@ def main():
             )
         else:
             raise AssertionError("a raising catalog must still raise on no data")
+
+    # 7. Reading every partition means a key recurs once per run that touched
+    #    it, and MERGE INTO rejects that with MERGE_CARDINALITY_VIOLATION.
+    #    Deduping to the newest row per key is what makes the prefix read
+    #    usable at all, so it is asserted rather than assumed.
+    calls = {}
+
+    class FakeCol:
+        def __init__(self, name):
+            self.name = name
+
+        def desc(self):
+            calls["ordered_desc_on"] = self.name
+            return self
+
+        def __eq__(self, other):
+            return ("eq", self.name, other)
+
+    class DedupeDF:
+        def __init__(self):
+            self.dropped = None
+
+        def withColumn(self, *_):
+            return self
+
+        def filter(self, cond):
+            calls["filtered"] = cond
+            return self
+
+        def drop(self, name):
+            self.dropped = name
+            return self
+
+    fake_window = mock.MagicMock()
+    fake_window.partitionBy.return_value.orderBy.return_value = "w"
+    with mock.patch.dict(sys.modules, {
+        "pyspark.sql": mock.MagicMock(Window=fake_window),
+        "pyspark.sql.functions": mock.MagicMock(
+            col=FakeCol, row_number=mock.MagicMock()),
+    }):
+        out = bronze._latest_per_key(DedupeDF(), "order_id")
+
+    assert fake_window.partitionBy.call_args[0][0] == "order_id", (
+        "must partition by the primary key")
+    assert calls.get("ordered_desc_on") == "updated_at", (
+        "must keep the newest row, ordering by updated_at descending, "
+        f"got {calls.get('ordered_desc_on')!r}")
+    assert out.dropped == "_row", "the helper column must not reach the MERGE"
 
     print("bronze load contract: OK")
 

--- a/spark/jobs/bronze.py
+++ b/spark/jobs/bronze.py
@@ -54,7 +54,7 @@ def read_all_partitions(spark, source_table):
     return df
 
 
-def load_bronze(spark, source_table, iceberg_table):
+def load_bronze(spark, source_table, iceberg_table, primary_key):
     """Return the Bronze DataFrame, or None when there is genuinely nothing to do.
 
     Raises when there is no Bronze data *and* the target Iceberg table does not
@@ -63,6 +63,8 @@ def load_bronze(spark, source_table, iceberg_table):
     for as long as it did.
     """
     df = read_all_partitions(spark, source_table)
+    if df is not None:
+        df = _latest_per_key(df, primary_key)
     count = df.count() if df is not None else 0
 
     if count == 0:
@@ -112,3 +114,34 @@ def _table_exists(spark, iceberg_table):
         print(f"Could not query the catalog for {iceberg_table} "
               f"({type(e).__name__}); treating it as absent.")
         return False
+
+
+def _latest_per_key(df, primary_key):
+    """Keep one row per key, the most recently updated.
+
+    Reading every retained partition means the same key appears once per run
+    that touched it: a row extracted on Monday and updated on Wednesday is in
+    both days' Bronze. MERGE INTO refuses that outright --
+
+      [MERGE_CARDINALITY_VIOLATION] The ON search condition of the MERGE
+      statement matched a single row from the target table with multiple rows
+      of the source table
+
+    -- and it is right to, because which of the duplicates should win is not
+    something SQL can guess. Reading a single day never hit this, so it arrived
+    with #151 rather than being latent.
+
+    updated_at is the answer: the ingestion DAG extracts on it as its
+    high-water mark, so the largest value is the newest version of the row by
+    the same definition the pipeline already uses. Ties keep an arbitrary row,
+    which is correct -- rows sharing a key and an updated_at are the same
+    version extracted twice.
+    """
+    from pyspark.sql import Window
+    from pyspark.sql.functions import col, row_number
+
+    ordering = Window.partitionBy(primary_key).orderBy(col("updated_at").desc())
+    deduped = (df.withColumn("_row", row_number().over(ordering))
+                 .filter(col("_row") == 1)
+                 .drop("_row"))
+    return deduped

--- a/spark/jobs/transform_customers.py
+++ b/spark/jobs/transform_customers.py
@@ -83,7 +83,7 @@ def main():
     
     try:
         print("Starting Spark Job: Customer Bronze to Silver")
-        bronze_df = load_bronze(spark, "customers", "silver.lake.customers")
+        bronze_df = load_bronze(spark, "customers", "silver.lake.customers", "customer_id")
         if bronze_df is None:
             return
         silver_df = transform_customers(bronze_df)

--- a/spark/jobs/transform_order_items.py
+++ b/spark/jobs/transform_order_items.py
@@ -75,7 +75,7 @@ def main():
     
     try:
         print("Starting Spark Job: OrderItems Bronze to Silver")
-        bronze_df = load_bronze(spark, "order_items", "silver.lake.order_items")
+        bronze_df = load_bronze(spark, "order_items", "silver.lake.order_items", "item_id")
         if bronze_df is None:
             return
         silver_df = transform_order_items(bronze_df)

--- a/spark/jobs/transform_orders.py
+++ b/spark/jobs/transform_orders.py
@@ -92,7 +92,7 @@ def main():
     spark = create_spark_session()
 
     try:
-        bronze_df = load_bronze(spark, "orders", "silver.lake.orders")
+        bronze_df = load_bronze(spark, "orders", "silver.lake.orders", "order_id")
         if bronze_df is None:
             return
         silver_df = transform_to_silver(bronze_df)

--- a/spark/jobs/transform_products.py
+++ b/spark/jobs/transform_products.py
@@ -80,7 +80,7 @@ def main():
     
     try:
         print("Starting Spark Job: Product Bronze to Silver")
-        bronze_df = load_bronze(spark, "products", "silver.lake.products")
+        bronze_df = load_bronze(spark, "products", "silver.lake.products", "product_id")
         if bronze_df is None:
             return
         silver_df = transform_products(bronze_df)


### PR DESCRIPTION
Found by running the pipeline end to end after #161, on a stack with several days of Bronze.

```
[MERGE_CARDINALITY_VIOLATION] The ON search condition of the MERGE statement
matched a single row from the target table with multiple rows of the source table
```

## Cause

Reading **every retained partition** means a key appears once per run that touched it — a row extracted Monday and updated Wednesday is in both days' Bronze. `MERGE INTO` refuses that, and rightly: which duplicate wins isn't something SQL can guess.

Reading one day at a time never hit it, so this **arrived with #151** rather than being latent. It lands on any cluster with more than one day of Bronze for a table that has ever been updated — which is every cluster, shortly.

## Fix

`updated_at` settles it. The ingestion DAG already extracts on that column as its high-water mark, so the largest value is the newest version of the row **by the definition the pipeline itself uses**. Ties keep an arbitrary row, which is correct: rows sharing a key and an `updated_at` are the same version extracted twice.

Done in `bronze.py` so all four jobs get it from one place, with the primary key passed by the caller.

## Verified against the running stack

| | Before | After |
|---|---|---|
| `transform_orders` | `MERGE_CARDINALITY_VIOLATION`, exit 1 | **exit 0** |
| rows read | 20,250 | 20,250 |
| rows merged | — | **10,000 distinct orders** |
| `iceberg.lake.orders` | 10000 | 10000 |

## Guard

Asserts the parts that would fail silently if changed: partitioning on the primary key, ordering by `updated_at` **descending**, and dropping the helper column before the frame reaches MERGE. Confirmed it fails when the ordering column is swapped.

`ruff`, `bandit -ll`, both CI guards clean.